### PR TITLE
chore: revert ps/ip command

### DIFF
--- a/dockerfiles/bases/pingcap-base/Dockerfile
+++ b/dockerfiles/bases/pingcap-base/Dockerfile
@@ -3,7 +3,4 @@
 # hub.pingcap.net/bases/pingcap-base:v1
 FROM rockylinux:9.1.20230215
 RUN --mount=from=busybox:1.36.0,source=/bin,target=/busybox/bin \
-	cp -a /busybox/bin/busybox /bin/busybox && \
-	# some dev ask for ps/ip command to debug
-	dnf install -y procps iproute && \
-	dnf clean all
+	cp -a /busybox/bin/busybox /bin/busybox


### PR DESCRIPTION
## Why:
- revert https://github.com/PingCAP-QE/artifacts/pull/25
- keep RUN --mount syntax for pingap-base only add one layer even with more operation