### PR TITLE
fix(security): upgrade packages

### DIFF
--- a/dockerfiles/bases/pd-base/Dockerfile
+++ b/dockerfiles/bases/pd-base/Dockerfile
@@ -1,6 +1,6 @@
-# hub.pingcap.net/bases/pd-base:v1.4.0
-# hub.pingcap.net/bases/pd-base:v1.4
+# hub.pingcap.net/bases/pd-base:v1.5.0
+# hub.pingcap.net/bases/pd-base:v1.5
 # hub.pingcap.net/bases/pd-base:v1
-FROM hub.pingcap.net/bases/pingcap-base:v1.4.0
+FROM hub.pingcap.net/bases/pingcap-base:v1.5.0
 RUN dnf install bind-utils wget -y && \
     dnf clean all

--- a/dockerfiles/bases/pingcap-base/Dockerfile
+++ b/dockerfiles/bases/pingcap-base/Dockerfile
@@ -1,9 +1,8 @@
-# hub.pingcap.net/bases/pingcap-base:v1.4.0
-# hub.pingcap.net/bases/pingcap-base:v1.4
+# hub.pingcap.net/bases/pingcap-base:v1.5.0
+# hub.pingcap.net/bases/pingcap-base:v1.5
 # hub.pingcap.net/bases/pingcap-base:v1
 FROM rockylinux:9.1.20230215
 RUN --mount=from=busybox:1.36.0,source=/bin,target=/busybox/bin \
 	cp -a /busybox/bin/busybox /bin/busybox && \
-	# some dev ask for ps/ip command to debug
-	dnf install -y procps iproute && \
+	dnf upgrade -y openssl lua-libs tar systemd-libs python3 python3-setuptools-wheel vim-minimal && \
 	dnf clean all

--- a/dockerfiles/bases/tidb-base/Dockerfile
+++ b/dockerfiles/bases/tidb-base/Dockerfile
@@ -1,5 +1,5 @@
-# hub.pingcap.net/bases/tidb-base:v1.4.0
-# hub.pingcap.net/bases/tidb-base:v1.4
+# hub.pingcap.net/bases/tidb-base:v1.5.0
+# hub.pingcap.net/bases/tidb-base:v1.5
 # hub.pingcap.net/bases/tidb-base:v1
-FROM hub.pingcap.net/bases/pingcap-base:v1.4.0
+FROM hub.pingcap.net/bases/pingcap-base:v1.5.0
 RUN dnf install --allowerasing -y curl && dnf clean all

--- a/dockerfiles/bases/tikv-base/Dockerfile
+++ b/dockerfiles/bases/tikv-base/Dockerfile
@@ -1,7 +1,7 @@
-# hub.pingcap.net/bases/tikv-base:v1.4.0
-# hub.pingcap.net/bases/tikv-base:v1.4
+# hub.pingcap.net/bases/tikv-base:v1.5.0
+# hub.pingcap.net/bases/tikv-base:v1.5
 # hub.pingcap.net/bases/tikv-base:v1
-FROM hub.pingcap.net/bases/pingcap-base:v1.4.0
+FROM hub.pingcap.net/bases/pingcap-base:v1.5.0
 RUN dnf install -y tzdata
 ENV TZ=/etc/localtime \
     TZDIR=/usr/share/zoneinfo

--- a/dockerfiles/bases/tools-base/Dockerfile
+++ b/dockerfiles/bases/tools-base/Dockerfile
@@ -1,5 +1,5 @@
-# hub.pingcap.net/bases/tools-base:v1.4.0
-# hub.pingcap.net/bases/tools-base:v1.4
+# hub.pingcap.net/bases/tools-base:v1.5.0
+# hub.pingcap.net/bases/tools-base:v1.5
 # hub.pingcap.net/bases/tools-base:v1
-FROM hub.pingcap.net/bases/pingcap-base:v1.4.0
+FROM hub.pingcap.net/bases/pingcap-base:v1.5.0
 RUN dnf install -y bind-utils wget nc && dnf clean all


### PR DESCRIPTION
Why:
![img_v2_bf602dbe-9647-46ca-a812-d0078f512a3g](https://user-images.githubusercontent.com/10222426/234521398-4d26472e-b5ff-49d9-9938-6fa0dd54b268.jpg)
![img_v2_17bf243d-1143-4d0b-8390-ab965bbbb4dg](https://user-images.githubusercontent.com/10222426/234521451-639370fe-c465-4484-b30b-f181f0135340.jpg)

- rocky has no newer release yet
- fix CVE for these upgraded packages