### PR TITLE
feat: tidb/tiflash add wget according to operator

### DIFF
--- a/dockerfiles/bases/Makefile
+++ b/dockerfiles/bases/Makefile
@@ -1,6 +1,6 @@
 Images  = $(shell gawk '/^\# hub/{printf "-t %s " , $$2}' $@/Dockerfile )
 
-all_bases := pingcap-base tidb-base tikv-base pd-base tools-base
+all_bases := pingcap-base tidb-base tikv-base pd-base tools-base tiflash-base
 $(all_bases) :
 	docker buildx build $@ $(Images) --push --platform=linux/amd64,linux/arm64
 

--- a/dockerfiles/bases/tidb-base/Dockerfile
+++ b/dockerfiles/bases/tidb-base/Dockerfile
@@ -1,5 +1,5 @@
-# hub.pingcap.net/bases/tidb-base:v1.5.0
+# hub.pingcap.net/bases/tidb-base:v1.5.1
 # hub.pingcap.net/bases/tidb-base:v1.5
 # hub.pingcap.net/bases/tidb-base:v1
 FROM hub.pingcap.net/bases/pingcap-base:v1.5.0
-RUN dnf install --allowerasing -y curl && dnf clean all
+RUN dnf install --allowerasing -y curl wget && dnf clean all

--- a/dockerfiles/bases/tiflash-base/Dockerfile
+++ b/dockerfiles/bases/tiflash-base/Dockerfile
@@ -1,0 +1,5 @@
+# hub.pingcap.net/bases/tiflash-base:v1.5.0
+# hub.pingcap.net/bases/tiflash-base:v1.5
+# hub.pingcap.net/bases/tiflash-base:v1
+FROM hub.pingcap.net/bases/pingcap-base:v1.5.0
+RUN dnf install --allowerasing -y wget && dnf clean all


### PR DESCRIPTION
Why:
- operator say they need wget when deploy across k8s cluster