### PR TITLE
fix(dockerfiles/bases/pingcap-base): bump the base images to make more security

### DIFF
--- a/dockerfiles/bases/pingcap-base/Dockerfile
+++ b/dockerfiles/bases/pingcap-base/Dockerfile
@@ -1,8 +1,7 @@
-# hub.pingcap.net/bases/pingcap-base:v1.5.0
-# hub.pingcap.net/bases/pingcap-base:v1.5
+# hub.pingcap.net/bases/pingcap-base:v1.6.0
+# hub.pingcap.net/bases/pingcap-base:v1.6
 # hub.pingcap.net/bases/pingcap-base:v1
-FROM rockylinux:9.1.20230215
+FROM rockylinux:9.2.20230513
 RUN --mount=from=busybox:1.36.0,source=/bin,target=/busybox/bin \
 	cp -a /busybox/bin/busybox /bin/busybox && \
-	dnf upgrade -y openssl lua-libs tar systemd-libs python3 python3-setuptools-wheel vim-minimal && \
 	dnf clean all

--- a/dockerfiles/bases/pingcap-base/Dockerfile
+++ b/dockerfiles/bases/pingcap-base/Dockerfile
@@ -2,6 +2,6 @@
 # hub.pingcap.net/bases/pingcap-base:v1.6
 # hub.pingcap.net/bases/pingcap-base:v1
 FROM rockylinux:9.2.20230513
-RUN --mount=from=busybox:1.36.0,source=/bin,target=/busybox/bin \
+RUN --mount=from=busybox:1.36.1,source=/bin,target=/busybox/bin \
 	cp -a /busybox/bin/busybox /bin/busybox && \
 	dnf clean all


### PR DESCRIPTION
# Why
- update rocky to 9.2 to make it more security with fixes.
- upgrade busybox to 1.36.1 to include updates from upstream image.
- remove `dnf upgrade` since the the package is updated in rocky 9.2, no need it again.

# What changes
- bump rocky image tag to 9.2 group
- bump busybox image tag to 1.36.1
- delete the no longer needed step: `dnf upgrade`.

# Additional
- already pass security scanning by security team