### PR TITLE
fix: base image security

### DIFF
--- a/dockerfiles/bases/Makefile
+++ b/dockerfiles/bases/Makefile
@@ -1,7 +1,12 @@
 Images  = $(shell gawk '/^\# hub/{printf "-t %s " , $$2}' $@/Dockerfile )
 
-all_bases := pingcap-base tidb-base tikv-base pd-base tools-base tiflash-base
-$(all_bases) :
+products_bases := tidb-base tikv-base pd-base tools-base tiflash-base
+pingcap-base :
 	docker buildx build $@ $(Images) --push --platform=linux/amd64,linux/arm64
 
-.PHONY : $(all_bases)
+$(products_bases) : pingcap-base
+	docker buildx build $@ $(Images) --push --platform=linux/amd64,linux/arm64
+
+all_bases : pingcap-base $(products_bases)
+
+.PHONY : pingcap-base $(products_bases) all_bases

--- a/dockerfiles/bases/pd-base/Dockerfile
+++ b/dockerfiles/bases/pd-base/Dockerfile
@@ -1,6 +1,6 @@
-# hub.pingcap.net/bases/pd-base:v1.6.1
-# hub.pingcap.net/bases/pd-base:v1.6
+# hub.pingcap.net/bases/pd-base:v1.7.0
+# hub.pingcap.net/bases/pd-base:v1.7
 # hub.pingcap.net/bases/pd-base:v1
-FROM hub.pingcap.net/bases/pingcap-base:v1.6.0
+FROM hub.pingcap.net/bases/pingcap-base:v1.7.0
 RUN dnf install bind-utils wget jq -y && \
     dnf clean all

--- a/dockerfiles/bases/pingcap-base/Dockerfile
+++ b/dockerfiles/bases/pingcap-base/Dockerfile
@@ -1,7 +1,8 @@
-# hub.pingcap.net/bases/pingcap-base:v1.6.0
-# hub.pingcap.net/bases/pingcap-base:v1.6
+# hub.pingcap.net/bases/pingcap-base:v1.7.0
+# hub.pingcap.net/bases/pingcap-base:v1.7
 # hub.pingcap.net/bases/pingcap-base:v1
 FROM rockylinux:9.2.20230513
 RUN --mount=from=busybox:1.36.1,source=/bin,target=/busybox/bin \
 	cp -a /busybox/bin/busybox /bin/busybox && \
+	dnf upgrade -y python3 less && \
 	dnf clean all

--- a/dockerfiles/bases/tidb-base/Dockerfile
+++ b/dockerfiles/bases/tidb-base/Dockerfile
@@ -1,5 +1,5 @@
-# hub.pingcap.net/bases/tidb-base:v1.6.0
-# hub.pingcap.net/bases/tidb-base:v1.6
+# hub.pingcap.net/bases/tidb-base:v1.7.0
+# hub.pingcap.net/bases/tidb-base:v1.7
 # hub.pingcap.net/bases/tidb-base:v1
-FROM hub.pingcap.net/bases/pingcap-base:v1.6.0
+FROM hub.pingcap.net/bases/pingcap-base:v1.7.0
 RUN dnf install --allowerasing -y curl wget && dnf clean all

--- a/dockerfiles/bases/tiflash-base/Dockerfile
+++ b/dockerfiles/bases/tiflash-base/Dockerfile
@@ -1,5 +1,5 @@
-# hub.pingcap.net/bases/tiflash-base:v1.6.0
-# hub.pingcap.net/bases/tiflash-base:v1.6
+# hub.pingcap.net/bases/tiflash-base:v1.7.0
+# hub.pingcap.net/bases/tiflash-base:v1.7
 # hub.pingcap.net/bases/tiflash-base:v1
-FROM hub.pingcap.net/bases/pingcap-base:v1.6.0
+FROM hub.pingcap.net/bases/pingcap-base:v1.7.0
 RUN dnf install --allowerasing -y wget && dnf clean all

--- a/dockerfiles/bases/tikv-base/Dockerfile
+++ b/dockerfiles/bases/tikv-base/Dockerfile
@@ -1,7 +1,7 @@
-# hub.pingcap.net/bases/tikv-base:v1.6.0
-# hub.pingcap.net/bases/tikv-base:v1.6
+# hub.pingcap.net/bases/tikv-base:v1.7.0
+# hub.pingcap.net/bases/tikv-base:v1.7
 # hub.pingcap.net/bases/tikv-base:v1
-FROM hub.pingcap.net/bases/pingcap-base:v1.6.0
+FROM hub.pingcap.net/bases/pingcap-base:v1.7.0
 # wget is requested by operator
 RUN dnf install -y tzdata wget && dnf clean all
 ENV TZ=/etc/localtime \

--- a/dockerfiles/bases/tools-base/Dockerfile
+++ b/dockerfiles/bases/tools-base/Dockerfile
@@ -1,5 +1,5 @@
-# hub.pingcap.net/bases/tools-base:v1.6.0
-# hub.pingcap.net/bases/tools-base:v1.6
+# hub.pingcap.net/bases/tools-base:v1.7.0
+# hub.pingcap.net/bases/tools-base:v1.7
 # hub.pingcap.net/bases/tools-base:v1
-FROM hub.pingcap.net/bases/pingcap-base:v1.6.0
+FROM hub.pingcap.net/bases/pingcap-base:v1.7.0
 RUN dnf install -y bind-utils wget nc && dnf clean all


### PR DESCRIPTION
Why:
- fix base image security
- 
![img_v2_245f6c0e-6075-42b2-aa39-0ddcfa5f426g](https://github.com/PingCAP-QE/artifacts/assets/10222426/b14110dc-1386-49b5-b250-4ad483bda4d3)

- better makefile for parallel build