### PR TITLE
fix(packges): add mac build targets for tiflow

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -102,9 +102,7 @@ components:
                 if [ "$(uname -m)" == "aarch64" ]; then
                     export JEMALLOC_SYS_WITH_LG_PAGE=16
                 fi
-                ROCKSDB_SYS_STATIC=1 make dist_release
-            - os: darwin
-              script: |
+            - script: |
                 ROCKSDB_SYS_STATIC=1 make dist_release
           debug:
             - os: linux
@@ -154,7 +152,7 @@ components:
           # ref: https://github.com/Masterminds/semver#checking-version-constraints
           constraints: ">=7.1.0-0"
           if: {{ semver.MatchConstraint ">=7.1.0-0" .Release.version }}
-        os: [linux]
+        os: [linux, darwin]
         arch: [amd64, arm64]
         profile: [release]
         artifactory:
@@ -166,7 +164,26 @@ components:
             - "{{ .Git.ref }}"
         steps:
           release:
-            - script: make cdc dm-master-with-webui dm-worker dmctl dm-syncer
+            - os: darwin
+              description: install nodejs toolchain.
+              script: |
+                NODE_VERSION="16.11.12"
+                NVM_VERSION=v0.39.5
+                NVM_DIR=/usr/local/nvm
+                mkdir -p $NVM_DIR
+
+                if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+                  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
+                fi
+                . $NVM_DIR/nvm.sh
+                nvm install ${NODE_VERSION}
+                nvm use v${NODE_VERSION}
+                nvm alias default v${NODE_VERSION}
+
+                node --version && npm --version
+                npm install -g yarn
+            - script: |
+                make cdc dm-master-with-webui dm-worker dmctl dm-syncer
         artifacts:
           - name: "cdc-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
             files:

--- a/packages/scripts/build-package-artifacts.sh.tmpl
+++ b/packages/scripts/build-package-artifacts.sh.tmpl
@@ -65,8 +65,11 @@ function print_help() {
 
 # >>>>>>>>>>>>>>>> build steps >>>>>>>>>>>>>>>>
 function build() {
+    {{- $root := . -}}
     {{- range .steps }}
-    {{ .script | indent 4 }}
+    {{- if or (not (has . "os")) (eq .os $root.os) }}
+{{ .script | indent 4 }}
+    {{- end }}
     {{- end }}
 }
 

--- a/packages/scripts/build-package-images.sh.tmpl
+++ b/packages/scripts/build-package-images.sh.tmpl
@@ -83,7 +83,6 @@ build_and_push_images() {
     {{- end }}
     {{- end }}
     {{- end }}
-    
     ## build and push
     dockerfile="{{ .dockerfile }}"
     # get dockerfile from url if the `.dockerfile` value is a http url.

--- a/packages/scripts/build-package-images.sh.tmpl
+++ b/packages/scripts/build-package-images.sh.tmpl
@@ -10,25 +10,25 @@ main() {
     mkdir -p ${release_ws}
     release_ws=$(realpath $release_ws)
 
-    # >>>>>>>>>>>>>>>> build steps >>>>>>>>>>>>>>>>
     if $need_build; then
-{{- range .steps }}
-{{ .script | indent 8 }}
-{{- end }}
+      build_binaries
     fi
-    # <<<<<<<<<<<<<<<< build steps <<<<<<<<<<<<<<<<
 
+    build_and_push_images
+}
+
+build_and_push_images() {
     ################# build and push image ################
     tag="{{ index .artifactory.tags 0 }}-{{ .profile }}-{{ .arch }}"
-{{- range (.artifacts | jq `map(select(.type == "image"))`) }}
+{{ range (.artifacts | jq `map(select(.type == "image"))`) }}
     # >>>>>>>>>>>>>>>> image: {{ .name }} >>>>>>>>>>>>>>>>
     destination="{{ .artifactory.repo  }}:$tag"
     kaniko_executor_global_options=""
 
-  {{- if has . "context" }}
+    {{- if has . "context" }}
     # just build it with native build from git repo's dockerfile
     $kaniko_executor $kaniko_executor_global_options --context={{ .context }} --dockerfile={{ .dockerfile }} --destination=${destination}
-  {{- else }}
+    {{- else }}
 
     # Prepare build context for image building.
     echo "Prepare build context for image: $destination ..."
@@ -83,7 +83,7 @@ main() {
     {{- end }}
     {{- end }}
     {{- end }}
-
+    
     ## build and push
     dockerfile="{{ .dockerfile }}"
     # get dockerfile from url if the `.dockerfile` value is a http url.
@@ -96,11 +96,22 @@ main() {
 
     $kaniko_executor $kaniko_executor_global_options --context="$archive_dir" --dockerfile="$dockerfile" --destination=${destination}
     rm -rf $archive_dir
-  {{- end }}
+    {{- end }}
 
     echo "Pushed image: $destination"
     # <<<<<<<<<<<<<<<< image: {{ .name }} <<<<<<<<<<<<<<<<
-{{- end }}
+{{ end }}
+    # All done.
+}
+
+# >>>>>>>>>>>>>>>> build binaries steps >>>>>>>>>>>>>>>>
+build_binaries() {
+  {{- $root := . -}}
+  {{- range .steps }}
+  {{- if or (not (has . "os")) (eq .os $root.os) }}
+{{ .script | indent 4 }}
+  {{- end }}
+  {{- end }}
 }
 
 main "$@"


### PR DESCRIPTION
What changes for tiflow
===
1. add `darwin` as support target os.
2. add os conditional steps for tiflow darwin targets, we use nvm to provide different nodejs versions. 