### PR TITLE
fix(packages/scripts): fix the script generations

### DIFF
--- a/packages/scripts/build-package-artifacts.sh.tmpl
+++ b/packages/scripts/build-package-artifacts.sh.tmpl
@@ -16,9 +16,11 @@ function main() {
     if $need_package; then
         archive "${release_ws}"
     fi
+{{- if has .artifactory "repo" }}
     if $need_push; then
         push_files "${release_ws}"
     fi
+{{- end }}
 }
 
 function parse_arguments() {
@@ -146,6 +148,7 @@ function archive() {
     {{- end }}
 }
 
+{{- if has .artifactory "repo" }}
 function push_files() {
     local release_ws="$1"
 
@@ -162,6 +165,7 @@ function push_files() {
         {{- range (.artifacts | jq `map(select(.type == "file" or .type == null))`) }}{{ printf " %s" .name }}{{- end }}
     popd
 }
+{{- end }}
 
 ##############################################################################
 ###### Call the main function with the arguments passed to the script ########

--- a/packages/scripts/gen-package-images-with-config.sh
+++ b/packages/scripts/gen-package-images-with-config.sh
@@ -15,13 +15,18 @@ function main() {
     local template_file="${8:-${PROJECT_ROOT_DIR}/packages/packages.yaml.tmpl}"
     local out_file="${9:-${RELEASE_SCRIPTS_DIR}/build-package-images.sh}"
 
+    if [ "$os" != "linux" ]; then
+        echo "Can not build container images for os: $os, only supports linux."
+        exit 1
+    fi
+
     # prepare template file's context.
     : >release-context.yaml
-    yq -i ".Release.os=\"$os\"" release-context.yaml
-    yq -i ".Release.arch=\"$arch\"" release-context.yaml
-    yq -i ".Release.version=\"$version\"" release-context.yaml
-    yq -i ".Git.ref=\"$git_ref\"" release-context.yaml
-    yq -i ".Git.sha=\"$git_sha\"" release-context.yaml
+    yq -i ".Release.os = \"$os\"" release-context.yaml
+    yq -i ".Release.arch = \"$arch\"" release-context.yaml
+    yq -i ".Release.version = \"$version\"" release-context.yaml
+    yq -i ".Git.ref = \"$git_ref\"" release-context.yaml
+    yq -i ".Git.sha = \"$git_sha\"" release-context.yaml
 
     gomplate --context .=release-context.yaml -f "$template_file" --out release-packages.yaml
 
@@ -41,18 +46,25 @@ function main() {
     fi
 
     if yq -e 'length == 0' release-package-routes.yaml >/dev/null 2>&1; then
-        echo "No package routes matched for arch: $arch, version: $version ."
+        echo "No package routes matched for component: $component, arch: $arch, version: $version ."
         exit 0
     fi
 
     # generate package build script
     yq ".[0]" release-package-routes.yaml >release-package.yaml
-    yq -i ".os=\"$os\"" release-package.yaml
-    yq -i ".arch=\"$arch\"" release-package.yaml
-    yq -i ".profile=\"$profile\"" release-package.yaml
-    yq -i ".steps=.steps[.profile]" release-package.yaml
+    yq -i ".os = \"$os\"" release-package.yaml
+    yq -i ".arch = \"$arch\"" release-package.yaml
+    yq -i ".profile = \"$profile\"" release-package.yaml
+    yq -i ".steps = .steps[.profile]" release-package.yaml
+    yq -i ".steps = (.steps | map(select(.os == null or .os == \"$os\")))" release-package.yaml
+    yq -i ".steps = (.steps | map(select(.arch == null or .arch == \"$arch\")))" release-package.yaml
     yq -i '.artifacts = (.artifacts | map(select(.type == "image")))' release-package.yaml
     yq -i ".artifacts[] |= (with(select((.context == null) and (.dockerfile | test(\"^http(s)?://\") | false)); .dockerfile = \"$PROJECT_ROOT_DIR/\" + .dockerfile))" release-package.yaml
+
+    if yq -e '.artifacts | length == 0' release-package.yaml >/dev/null 2>&1; then
+        echo "No images should be built for component: $component, arch: $arch, version: $version ."
+        exit 0
+    fi
 
     gomplate --context .=release-package.yaml -f $RELEASE_SCRIPTS_DIR/build-package-images.sh.tmpl --chmod "755" --out $out_file
     echo "Generated shell script: $out_file"


### PR DESCRIPTION
- exit with error when build image with os not equal "linux"
- skip generate the script when `.artifacts` is empty.
- if there haven't top `.artifactory` set for binaries artifacts, it should not have the push step in shell script.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>