### PR TITLE
chore: bump base image

### DIFF
--- a/dockerfiles/br.Dockerfile
+++ b/dockerfiles/br.Dockerfile
@@ -1,2 +1,2 @@
-FROM hub.pingcap.net/bases/pingcap-base:v1.7.0
+FROM hub.pingcap.net/bases/pingcap-base:v1.8.0
 COPY br /br

--- a/dockerfiles/dm.Dockerfile
+++ b/dockerfiles/dm.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/bases/tools-base:v1.7.0
+FROM hub.pingcap.net/bases/tools-base:v1.8.0
 COPY dm-worker /dm-worker
 COPY dm-master /dm-master
 COPY dmctl /dmctl

--- a/dockerfiles/dumpling.Dockerfile
+++ b/dockerfiles/dumpling.Dockerfile
@@ -1,2 +1,2 @@
-FROM hub.pingcap.net/bases/tools-base:v1.7.0
+FROM hub.pingcap.net/bases/tools-base:v1.8.0
 COPY dumpling /dumpling

--- a/dockerfiles/ng-monitoring.Dockerfile
+++ b/dockerfiles/ng-monitoring.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/bases/ng-monitoring-base:v1.7.0
+FROM hub.pingcap.net/bases/ng-monitoring-base:v1.8.0
 COPY ng-monitoring-server /ng-monitoring-server
 EXPOSE 12020
 ENTRYPOINT ["/ng-monitoring-server"]

--- a/dockerfiles/pd.Dockerfile
+++ b/dockerfiles/pd.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/bases/pd-base:v1.7.1
+FROM hub.pingcap.net/bases/pd-base:v1.8.0
 COPY pd-server /pd-server
 COPY pd-ctl /pd-ctl
 COPY pd-recover /pd-recover

--- a/dockerfiles/products/br.Dockerfile
+++ b/dockerfiles/products/br.Dockerfile
@@ -1,3 +1,3 @@
-ARG BASE_IMG=hub.pingcap.net/bases/pingcap-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/pingcap-base:v1.8.0
 FROM $BASE_IMG
 COPY br /br

--- a/dockerfiles/products/dm.Dockerfile
+++ b/dockerfiles/products/dm.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.8.0
 FROM $BASE_IMG
 COPY dm-worker /dm-worker
 COPY dm-master /dm-master

--- a/dockerfiles/products/dumpling.Dockerfile
+++ b/dockerfiles/products/dumpling.Dockerfile
@@ -1,3 +1,3 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.8.0
 FROM $BASE_IMG
 COPY dumpling /dumpling

--- a/dockerfiles/products/ng-monitoring.Dockerfile
+++ b/dockerfiles/products/ng-monitoring.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/ng-monitoring-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/ng-monitoring-base:v1.8.0
 FROM $BASE_IMG
 COPY ng-monitoring-server /ng-monitoring-server
 EXPOSE 12020

--- a/dockerfiles/products/pd.Dockerfile
+++ b/dockerfiles/products/pd.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/pd-base:v1.7.1
+ARG BASE_IMG=hub.pingcap.net/bases/pd-base:v1.8.0
 FROM $BASE_IMG
 COPY pd-server /pd-server
 COPY pd-ctl /pd-ctl

--- a/dockerfiles/products/ticdc.Dockerfile
+++ b/dockerfiles/products/ticdc.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.8.0
 FROM $BASE_IMG
 COPY cdc /cdc
 EXPOSE 8300

--- a/dockerfiles/products/tidb-binlog.Dockerfile
+++ b/dockerfiles/products/tidb-binlog.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.8.0
 FROM $BASE_IMG
 COPY pump /pump
 COPY drainer /drainer

--- a/dockerfiles/products/tidb-enterprise.Dockerfile
+++ b/dockerfiles/products/tidb-enterprise.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tidb-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tidb-base:v1.8.0
 FROM $BASE_IMG
 COPY tidb-server /tidb-server
 COPY audit-1.so /plugins/audit-1.so

--- a/dockerfiles/products/tidb-lightning-debug.Dockerfile
+++ b/dockerfiles/products/tidb-lightning-debug.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.8.0
 FROM $BASE_IMG
 COPY tidb-lightning /tidb-lightning
 COPY tidb-lightning-ctl /tidb-lightning-ctl

--- a/dockerfiles/products/tidb-lightning.Dockerfile
+++ b/dockerfiles/products/tidb-lightning.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.8.0
 FROM $BASE_IMG
 COPY tidb-lightning /tidb-lightning
 COPY tidb-lightning-ctl /tidb-lightning-ctl

--- a/dockerfiles/products/tidb-tools.Dockerfile
+++ b/dockerfiles/products/tidb-tools.Dockerfile
@@ -1,3 +1,3 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tools-base:v1.8.0
 FROM $BASE_IMG
 COPY sync_diff_inspector /sync_diff_inspector

--- a/dockerfiles/products/tidb.Dockerfile
+++ b/dockerfiles/products/tidb.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tidb-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tidb-base:v1.8.0
 FROM $BASE_IMG
 COPY tidb-server /tidb-server
 EXPOSE 4000

--- a/dockerfiles/products/tiflash.Dockerfile
+++ b/dockerfiles/products/tiflash.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tiflash-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tiflash-base:v1.8.0
 FROM $BASE_IMG
 ENV LD_LIBRARY_PATH /tiflash
 COPY tiflash /tiflash

--- a/dockerfiles/products/tikv.Dockerfile
+++ b/dockerfiles/products/tikv.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=hub.pingcap.net/bases/tikv-base:v1.7.0
+ARG BASE_IMG=hub.pingcap.net/bases/tikv-base:v1.8.0
 FROM $BASE_IMG
 COPY tikv-server /tikv-server
 COPY tikv-ctl /tikv-ctl

--- a/dockerfiles/ticdc.Dockerfile
+++ b/dockerfiles/ticdc.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/bases/tools-base:v1.7.0
+FROM hub.pingcap.net/bases/tools-base:v1.8.0
 COPY cdc /cdc
 EXPOSE 8300
 

--- a/dockerfiles/tidb-binlog.Dockerfile
+++ b/dockerfiles/tidb-binlog.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/bases/tools-base:v1.7.0
+FROM hub.pingcap.net/bases/tools-base:v1.8.0
 COPY pump /pump
 COPY drainer /drainer
 COPY reparo /reparo

--- a/dockerfiles/tidb-enterprise.Dockerfile
+++ b/dockerfiles/tidb-enterprise.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/bases/tidb-base:v1.7.0
+FROM hub.pingcap.net/bases/tidb-base:v1.8.0
 COPY tidb-server /tidb-server
 COPY audit-1.so /plugins/audit-1.so
 COPY whitelist-1.so /plugins/whitelist-1.so

--- a/dockerfiles/tidb-lightning-debug.Dockerfile
+++ b/dockerfiles/tidb-lightning-debug.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/bases/tools-base:v1.7.0
+FROM hub.pingcap.net/bases/tools-base:v1.8.0
 COPY tidb-lightning /tidb-lightning
 COPY tidb-lightning-ctl /tidb-lightning-ctl
 COPY br /br

--- a/dockerfiles/tidb-lightning.Dockerfile
+++ b/dockerfiles/tidb-lightning.Dockerfile
@@ -1,3 +1,3 @@
-FROM hub.pingcap.net/bases/tools-base:v1.7.0
+FROM hub.pingcap.net/bases/tools-base:v1.8.0
 COPY tidb-lightning /tidb-lightning
 COPY tidb-lightning-ctl /tidb-lightning-ctl

--- a/dockerfiles/tidb-tools.Dockerfile
+++ b/dockerfiles/tidb-tools.Dockerfile
@@ -1,2 +1,2 @@
-FROM hub.pingcap.net/bases/tools-base:v1.7.0
+FROM hub.pingcap.net/bases/tools-base:v1.8.0
 COPY sync_diff_inspector /sync_diff_inspector

--- a/dockerfiles/tidb.Dockerfile
+++ b/dockerfiles/tidb.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/bases/tidb-base:v1.7.0
+FROM hub.pingcap.net/bases/tidb-base:v1.8.0
 COPY tidb-server /tidb-server
 EXPOSE 4000
 ENTRYPOINT ["/tidb-server"]

--- a/dockerfiles/tiflash.Dockerfile
+++ b/dockerfiles/tiflash.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/bases/tiflash-base:v1.7.0
+FROM hub.pingcap.net/bases/tiflash-base:v1.8.0
 ENV LD_LIBRARY_PATH /tiflash
 COPY tiflash /tiflash
 ENTRYPOINT ["/tiflash/tiflash", "server"]

--- a/dockerfiles/tikv.Dockerfile
+++ b/dockerfiles/tikv.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.pingcap.net/bases/tikv-base:v1.7.0
+FROM hub.pingcap.net/bases/tikv-base:v1.8.0
 COPY tikv-server /tikv-server
 COPY tikv-ctl /tikv-ctl
 ENV MALLOC_CONF="prof:true,prof_active:false"


### PR DESCRIPTION
# Why:
- bump base image version to fix security problems
- zero security issues scanned by security team