### PR TITLE
fix(packages): add tiup metadata for cdc

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1104,6 +1104,10 @@ components:
               - name: cdc
                 src:
                   path: bin/cdc
+            tiup:
+              description: >-
+                CDC is a change data capture tool for TiDB
+              entrypoint: cdc
           - name: "dm-master-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
             files:
               - name: dm-master/dm-master


### PR DESCRIPTION
cdc is in tiflow repo.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>