### PR TITLE
fix: prometheus path

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -201,9 +201,14 @@ components:
               - name: prometheus # must be first.
                 src:
                   type: http
-                  url: https://download.pingcap.org/prometheus-{{ if and (eq .Release.os "darwin") (eq .Release.arch "arm64") }}2.28.1{{ else }}2.27.1{{ end }}.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
+                  {{- if and (eq .Release.os "darwin") (eq .Release.arch "arm64") }}
+                  url: https://download.pingcap.org/prometheus-2.28.1.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
+                  extract_inner_path: prometheus-2.28.1.{{ .Release.os }}-{{ .Release.arch }}
+                  {{ else }}
+                  url: https://download.pingcap.org/prometheus-2.27.1.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
+                  extract_inner_path: prometheus-2.27.1.{{ .Release.os }}-{{ .Release.arch }}
+                  {{ end }}
                   extract: true
-                  extract_inner_path: prometheus-{{ if and (eq .Release.os "darwin") (eq .Release.arch "arm64") }}2.28.1{{ else }}2.27.1{{ end }}.{{ .Release.os }}-{{ .Release.arch }}
               - name: prometheus/tidb.rules.yml
                 src:
                   type: http

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -207,7 +207,7 @@ components:
                   {{- else }}
                   url: https://download.pingcap.org/prometheus-2.27.1.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
                   extract_inner_path: prometheus-2.27.1.{{ .Release.os }}-{{ .Release.arch }}
-                  {{ end }}
+                  {{- end }}
                   extract: true
               - name: prometheus/tidb.rules.yml
                 src:

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -201,13 +201,13 @@ components:
               - name: prometheus # must be first.
                 src:
                   type: http
-                  url: https://download.pingcap.org/prometheus-2.8.1.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
+                  url: https://download.pingcap.org/prometheus-{{ if and (eq .Release.os "darwin") (eq .Release.arch "arm64") }}2.28.1{{ else }}2.27.1{{ end }}.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
                   extract: true
-                  extract_inner_path: prometheus-2.8.1.{{ .Release.os }}-{{ .Release.arch }}
+                  extract_inner_path: prometheus-{{ if and (eq .Release.os "darwin") (eq .Release.arch "arm64") }}2.28.1{{ else }}2.27.1{{ end }}.{{ .Release.os }}-{{ .Release.arch }}
               - name: prometheus/tidb.rules.yml
                 src:
                   type: http
-                  url: 'https://raw.githubusercontent.com/pingcap/tidb/{{ .Git.ref }}/{{ if semver.CheckConstraint "> 7.5.0-0" .Release.version }}pkg/{{ end }}metrics/grafana/DM-Monitor-Professional.json'
+                  url: 'https://raw.githubusercontent.com/pingcap/tidb/{{ .Git.ref }}/{{ if semver.CheckConstraint "> 7.5.0-0" .Release.version }}pkg/{{ end }}metrics/alertmanager/tidb.rules.yml'
               - name: prometheus/pd.rules.yml
                 src:
                   type: http

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -204,7 +204,7 @@ components:
                   {{- if and (eq .Release.os "darwin") (eq .Release.arch "arm64") }}
                   url: https://download.pingcap.org/prometheus-2.28.1.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
                   extract_inner_path: prometheus-2.28.1.{{ .Release.os }}-{{ .Release.arch }}
-                  {{ else }}
+                  {{- else }}
                   url: https://download.pingcap.org/prometheus-2.27.1.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
                   extract_inner_path: prometheus-2.27.1.{{ .Release.os }}-{{ .Release.arch }}
                   {{ end }}


### PR DESCRIPTION
Why:
- mac/darwin has different version
- the version is a param and changed during groovy run, which misleads former PR