### PR TITLE
fix build-package-images.sh.tmpl

### DIFF
--- a/packages/scripts/build-package-images.sh.tmpl
+++ b/packages/scripts/build-package-images.sh.tmpl
@@ -86,7 +86,7 @@ build_and_push_images() {
     mkdir -p "$archive_dir"
     destination="{{ .artifactory.repo  }}:$tag"
     digest_file="${archive_dir}/digest.txt"
-    kaniko_executor_global_options="--destination=${destination} --digest-file=${digest_file}"
+    kaniko_executor_global_options="--cache-run-layers --destination=${destination} --digest-file=${digest_file}"
     {{- if has . "build_args" }}
     {{- range .build_args }}
     kaniko_executor_global_options="$kaniko_executor_global_options --build-arg {{.}}"


### PR DESCRIPTION
Avoid kaniko cache issue

Ref: https://github.com/GoogleContainerTools/kaniko/issues/1469