### PR TITLE
fix: tiflow-operator builder

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1415,7 +1415,7 @@ components:
         {{- end }}
         - {{ strings.ReplaceAll "/" "-" .Git.ref | strings.ToLower }}
     builders:
-      - image: ghcr.io/pingcap-qe/cd/builders/tiflow:v20231115-e1c4b43-go1.18
+      - image: ghcr.io/pingcap-qe/cd/utils/release:v20231216-14-g77d0cd2
     routers:
       - description: interpret versions according to semantic version spec.
         os: [linux]
@@ -1424,13 +1424,8 @@ components:
         builders: # TODO: fill the builder.
         steps:
           release:
-            - script: go build -o manager
+            - script: ""
         artifacts:
-          - name: "tiflow-operator-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
-            files:
-              - name: manager
-                src:
-                  path: manager
           - name: container image
             type: image
             artifactory:

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1423,7 +1423,7 @@ components:
         profile: [release]
         steps:
           release:
-            - script: ""
+            - script: "echo skip"
         artifacts:
           - name: container image
             type: image

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1421,7 +1421,6 @@ components:
         os: [linux]
         arch: [amd64, arm64]
         profile: [release]
-        builders: # TODO: fill the builder.
         steps:
           release:
             - script: ""

--- a/packages/scripts/ci.sh
+++ b/packages/scripts/ci.sh
@@ -41,6 +41,15 @@ function test_get_builder() {
             $script $cm $os $ac $version $profile
         done
     done
+     # tiflow-operator
+    local cm="tiflow-operator"
+    local os="linux"
+    for ac in $architectures; do
+        for version in v6.4.0-20221102-1667359250 v20221018; do
+            echo "$cm $os $ac $version:"
+            $script $cm $os $ac $version $profile
+        done
+    done
 
     # advanced-statefulset
     local cm="advanced-statefulset"
@@ -104,6 +113,16 @@ function test_gen_package_artifacts_script() {
         done
     done
 
+    # tiflow-operator
+    local cm="tiflow-operator"
+    local os="linux"
+    for ac in $architectures; do
+        for version in v6.4.0-20221102-1667359250 v20221018; do
+            echo "$cm $os $ac $version:"
+            $script $cm $os $ac $version $profile branch-xxx 123456789abcdef
+        done
+    done
+
     # advanced-statefulset
     local cm="advanced-statefulset"
     local os="linux"
@@ -156,6 +175,15 @@ function test_gen_package_images_script() {
     local os="linux"
     for ac in $architectures; do
         for version in v1.6.0 v1.5.0; do
+            echo "$cm $os $ac $version:"
+            $script $cm linux $ac $version $profile branch-xxx 123456789abcdef
+        done
+    done
+    # tiflow-operator
+    local cm="tiflow-operator"
+    local os="linux"
+    for ac in $architectures; do
+        for version in v6.4.0-20221102-1667359250 v20221018; do
             echo "$cm $os $ac $version:"
             $script $cm linux $ac $version $profile branch-xxx 123456789abcdef
         done


### PR DESCRIPTION
# Why:
- update builder image
- no binary needed