### PR TITLE
feat(packages): add `enterprise-without-plugins` profile for tidb repo

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -608,6 +608,9 @@ components:
                 # go plugin whitelist
                 pushd ../enterprise-plugin/whitelist && go mod tidy &&  popd
                 go run ./cmd/pluginpkg -pkg-dir ../enterprise-plugin/whitelist -out-dir bin/
+          enterprise-without-plugins:
+            - script: |
+                TIDB_EDITION=Enterprise make enterprise-prepare enterprise-server-build build_tools build_dumpling                
           debug:
             - script: |
                 make failpoint-enable


### PR DESCRIPTION
It will not build the go plugins, and it's valid from v7.1.0.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>