### PR TITLE
feat(packages): add image copy scripts

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -1,15 +1,18 @@
+# yaml-language-server: $schema=./delivery-schema.json
 image_copy_rules:
-  hub.pingcap.net/pingcap/tidb/images/tidb-server: # source repository
+  hub.pingcap.net/pingcap/tidb/images/tidb-server:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
       dest_repositories: # full repo url
         - docker.io/pingcap/tidb
-      constant_tags: [master, nightly] # override dest tags.
-    - tags_regex: [^latest$]
+      constant_tags: [nightly] # add new tags.
+    - description: publish latest image
+      tags_regex: [^latest$]
       dest_repositories: # full repo url
         - docker.io/pingcap/tidb
   hub.pingcap.net/pingcap/tiproxy/image:
-    - tags_regex:
+    - description: publish trunk and version images.
+      tags_regex:
         - ^v\d+\.\d+\.\d
         - ^(main|master)(-.+)?$
       dest_repositories:

--- a/packages/scripts/gen-delivery-image-commands.ts
+++ b/packages/scripts/gen-delivery-image-commands.ts
@@ -1,0 +1,84 @@
+import { parse } from "https://deno.land/std@0.194.0/flags/mod.ts";
+import * as yaml from "https://deno.land/std@0.214.0/yaml/mod.ts";
+
+interface Rule {
+  description?: string;
+  tags_regex: string[];
+  dest_repositories: string[];
+  constant_tags?: string[];
+}
+
+interface Config {
+  [sourceRepo: string]: Rule[];
+}
+
+async function generateShellScript(
+  imageUrlWithTag: string,
+  yamlFile: string,
+  outFile: string,
+) {
+  // Extract image URL and tag
+  const [imageUrl, tag] = imageUrlWithTag.split(":");
+
+  // Read YAML config
+  const config = yaml.parse(
+    await Deno.readTextFile(yamlFile),
+  ) as { image_copy_rules: Config };
+
+  // Retrieve rules for the source repository from the YAML config
+  const rules = (config.image_copy_rules[imageUrl] || []).filter((r) =>
+    r.tags_regex.some((regex) => new RegExp(regex).test(tag))
+  );
+
+  if (rules.length === 0) {
+    return;
+  }
+
+  // Open output file
+  const file = await Deno.open(outFile, {
+    create: true,
+    write: true,
+    truncate: true,
+  });
+
+  // Loop through rules
+  for (const rule of rules) {
+    const { description = "", dest_repositories, constant_tags = [] } = rule;
+
+    console.log(
+      `Matching rule found for image URL '${imageUrlWithTag}':`,
+    );
+    console.log(`\tDescription: ${description}`);
+    console.log(`\tSource Repository: ${imageUrl}`);
+
+    // Copy image to destination repositories using crane copy command
+    for (const destRepo of dest_repositories) {
+      console.log(`\tDestination Repository: ${destRepo}`);
+      await file.write(
+        new TextEncoder().encode(
+          `crane copy ${imageUrlWithTag} ${destRepo}:${tag}\n`,
+        ),
+      );
+      for (const constTag of constant_tags) {
+        await file.write(
+          new TextEncoder().encode(
+            `crane tag ${destRepo}:${tag} ${constTag}\n`,
+          ),
+        );
+      }
+    }
+  }
+
+  // Close output file
+  file.close();
+}
+
+// Parse command-line arguments
+const {
+  image_url,
+  yaml_file = "./packages/delivery.yaml",
+  outfile = "./delivery-images.sh",
+} = parse(Deno.args);
+
+// Example usage
+await generateShellScript(image_url, yaml_file, outfile);

--- a/packages/scripts/gen-delivery-images-with-config.sh
+++ b/packages/scripts/gen-delivery-images-with-config.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_SCRIPTS_DIR=$(dirname "$(readlink -f "$0")")
+PROJECT_ROOT_DIR=$(realpath "${RELEASE_SCRIPTS_DIR}/../..")
+
+# Function to copy container image to destination repositories based on rules defined in YAML config
+main() {
+    local image_url_with_tag="$1"
+    local yaml_file="${2:-${PROJECT_ROOT_DIR}/packages/delivery.yaml}"
+    local out_file="${3:-${RELEASE_SCRIPTS_DIR}/delivery-images.sh}"
+    rm -rf $out_file
+
+    # Extract image URL and tag
+    local image_url=$(echo "$image_url_with_tag" | cut -d ':' -f1)
+    local tag=$(echo "$image_url_with_tag" | cut -d ':' -f2)
+
+    # Retrieve rules for the source repository from the YAML config
+    local rules=$(yq ".image_copy_rules[\"$image_url\"]" "$yaml_file")
+    local rule_count=$(yq ".image_copy_rules[\"$image_url\"] | length" "$yaml_file")
+    if [ $rule_count -eq 0 ]; then
+        echo "🤷 none rules found for image: $image_url"
+        exit 0
+    fi
+
+    # Loop through each rule for the source repository
+    for ri in $(seq 0 $((rule_count - 1))); do
+        echo $ri
+        local rule=$(yq ".image_copy_rules[\"$image_url\"][$ri]" "$yaml_file")
+        description=$(yq '.description' <<< "$rule")
+        dest_repos=$(yq '.dest_repositories[]' <<< "$rule")
+        dest_tags=
+
+        # Check if the tag matches the tags regex
+        if yq -e ".tags_regex[] | select(. | test \"$tag\")" 2>&1> /dev/null <<< "$rule" ; then
+            echo "Matching rule found for image URL '$image_url_with_tag':"
+            echo "  Description: $description"
+            echo "  Source Repository: $image_url"
+
+            # Copy image to destination repositories using crane copy command
+            for dest_repo in $dest_repos; do
+                echo "  Destination Repository: $dest_repo"
+                echo "crane copy $image_url_with_tag $dest_repo:$tag" >> "$out_file"
+                for constant_tag in $(yq '.constant_tags[]' <<< "$rule"); do
+                    echo "crane tag $dest_repo:$tag $constant_tag" >> "$out_file"
+                done
+            done
+        fi
+    done
+
+    if [ -f "$out_file" ]; then
+        echo "✅ Generated shell script: $out_file"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
central congfig to control image delivery:
1. the config yaml.
2. the script to generate the shell commands, make it able to debug local before deploy on CD flows.