### PR TITLE
fix: tidb-lighting image path

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -24,7 +24,7 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/br
-  hub.pingcap.net/pingcap/tidb/images/lightning:
+  hub.pingcap.net/pingcap/tidb/images/tidb-lightning:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
       dest_repositories:


### PR DESCRIPTION
Why:
- fix tidb-lightning path