### PR TITLE
fix(pacakges): update the downloading url for etcd binary

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -77,7 +77,17 @@ components:
               - name: etcdctl
                 src:
                   type: http
+                  {{- if eq .Release.os "darwin" }}
+                  # ${FILE_SERVER_URL}/download/pingcap/etcd-${ETCDCTL_VERSION}-${os}-${arch}.tar.gz
+                  # Notice: it only support darwin arm64 platform from [v3.5.5](https://github.com/etcd-io/etcd/releases/tag/v3.5.5) in office artifacts.
+                  # When we upgrade to 3.5.x, we should replace it with the following url:
+                  # "https://github.com/etcd-io/etcd/releases/download/v3.4.21/etcd-v3.4.21-{{ .Release.os }}-{{ .Release.arch }}.zip"
+                  # Also we need support extract from zip archive.
+                  url: "http://fileserver.pingcap.net/download/pingcap/etcd-v3.4.21-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"                  
+                  {{- else }}
                   url: "https://github.com/etcd-io/etcd/releases/download/v3.4.21/etcd-v3.4.21-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  {{- end }}
+                  url: "http://fileserver.pingcap.net/download/pingcap/etcd-v3.4.21-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: etcd-v3.4.21-{{ .Release.os }}-{{ .Release.arch }}/etcdctl
               - name: pd-ctl

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -87,7 +87,6 @@ components:
                   {{- else }}
                   url: "https://github.com/etcd-io/etcd/releases/download/v3.4.21/etcd-v3.4.21-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   {{- end }}
-                  url: "http://fileserver.pingcap.net/download/pingcap/etcd-v3.4.21-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: etcd-v3.4.21-{{ .Release.os }}-{{ .Release.arch }}/etcdctl
               - name: pd-ctl


### PR DESCRIPTION
It supports darwin arm64 buiding from v3.5.5 by etcd-io office source.

Ref: https://github.com/etcd-io/etcd/issues/14001
Signed-off-by: wuhuizuo <wuhuizuo@126.com>