### PR TITLE
refactor(pingcap/ng-monitoring,pingcap/monitoring): drive the "prometheus" tiup pkg building from `pingcap/monitoring`

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -137,8 +137,8 @@ components:
     builders: # binary builder, also we need it when build for mac to get build tools versions and other informations.
       - image: golang:1.21.6
     routers:
-      - description: For range [7.1.0, )
-        if: {{ semver.CheckConstraint ">= 7.1.0-0" .Release.version }}
+      - description: For range [6.1.0, )
+        if: {{ semver.CheckConstraint ">= 6.1.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
         profile: [release]
@@ -168,38 +168,6 @@ components:
                 src:
                   path: ng-monitoring/bin/ng-monitoring-server
               - name: prometheus
-                src:
-                  path: output/prometheus
-            tiup:
-              description: The Prometheus monitoring system and time series database
-              entrypoint: prometheus/prometheus
-      - description: For range [6.1.0, )
-        if: {{ semver.CheckConstraint ">= 6.1.0-0, < 7.1.0-0" .Release.version }}
-        os: [linux, darwin]
-        arch: [amd64, arm64]
-        profile: [release]
-        steps:
-          release:
-            - script: |-
-                export TARGET={{ .Git.ref }}
-                export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}
-                # TODO(lijie0123): please backport to 6.x LTS versions.
-                go run ./cmd/monitoring.go --config=monitoring.yaml --tag={{ .Git.ref }}
-                make default -C ng-monitoring
-                make output/prometheus
-        artifacts:
-          - name: container image
-            type: image
-            artifactory:
-              repo: hub.pingcap.net/pingcap/monitoring/image
-            context: monitor-snapshot/{{ .Git.ref }}/operator/
-            dockerfile: Dockerfile
-          - name: "prometheus-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
-            files: # output files.
-              - name: ng-monitoring-server
-                src:
-                  path: ng-monitoring/bin/ng-monitoring-server
-              - name: prometheus # must be first.
                 src:
                   path: output/prometheus
             tiup:

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -148,6 +148,8 @@ components:
                 export TARGET={{ .Git.ref }}
                 export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}
                 make grafana_without_pull
+                make default -C ng-monitoring
+                make output/prometheus
         artifacts:
           - name: container image
             type: image
@@ -160,15 +162,30 @@ components:
             tiup:
               description: Grafana is the open source analytics & monitoring solution for every database
               entrypoint: bin/grafana-server
+          - name: "prometheus-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files: # output files.
+              - name: ng-monitoring-server
+                src:
+                  path: ng-monitoring/bin/ng-monitoring-server
+              - name: prometheus # must be first.
+                src:
+                  path: output/prometheus
+            tiup:
+              description: The Prometheus monitoring system and time series database
+              entrypoint: prometheus/prometheus
       - description: For range [6.1.0, )
-        if: {{ semver.CheckConstraint ">= 6.1.0-0 <7.1.0-0" .Release.version }}
+        if: {{ semver.CheckConstraint ">= 6.1.0-0, < 7.1.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
         profile: [release]
         steps:
           release:
             - script: >-
+                export TARGET={{ .Git.ref }}
+                export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}            
                 go run ./cmd/monitoring.go --config=monitoring.yaml --tag={{ .Git.ref }}
+                make default -C ng-monitoring
+                make output/prometheus
         artifacts:
           - name: container image
             type: image
@@ -176,8 +193,65 @@ components:
               repo: hub.pingcap.net/pingcap/monitoring/image
             context: monitor-snapshot/{{ .Git.ref }}/operator/
             dockerfile: Dockerfile
+          - name: "prometheus-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files: # output files.
+              - name: ng-monitoring-server
+                src:
+                  path: ng-monitoring/bin/ng-monitoring-server
+              - name: prometheus # must be first.
+                src:
+                  path: output/prometheus
+            tiup:
+              description: The Prometheus monitoring system and time series database
+              entrypoint: prometheus/prometheus
+      - description: For ragne [v5.3.0, 6.1.0)
+        if: {{ semver.CheckConstraint ">= 5.3.0-0, < 6.1.0-0" .Release.version }}
+        os: [linux, darwin]
+        arch: [amd64, arm64]
+        profile: [release]
+        steps:
+          release:
+            - script: |-
+                export TARGET={{ .Git.ref }}
+                export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}                
+                go run ./cmd/monitoring.go --config=monitoring.yaml --tag={{ .Git.ref }}
+                make default -C ng-monitoring
+                make output/prometheus
+        artifacts:
+          - name: "prometheus-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files: # output files.
+              - name: ng-monitoring-server
+                src:
+                  path: ng-monitoring/bin/ng-monitoring-server
+              - name: prometheus # must be first.
+                src:
+                  path: output/prometheus
+            tiup:
+              description: The Prometheus monitoring system and time series database
+              entrypoint: prometheus/prometheus
+      - description: For v5.2.x
+        if: {{ semver.CheckConstraint "~5.2.0-0" .Release.version }}
+        os: [linux]
+        arch: [amd64, arm64]
+        profile: [release]
+        steps:
+          release:
+            - script: |-
+                export TARGET={{ .Git.ref }}
+                export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}                
+                go run ./cmd/monitoring.go --config=monitoring.yaml --tag={{ .Git.ref }}
+                make output/prometheus
+        artifacts:
+          - name: "prometheus-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files: # output files.
+              - name: prometheus # must be first.
+                src:
+                  path: output/prometheus
+            tiup:
+              description: The Prometheus monitoring system and time series database
+              entrypoint: prometheus/prometheus
   ng-monitoring:
-    desc: ng-monitoring component tarball
+    desc: ng-monitoring component
     git:
       url: https://github.com/pingcap/ng-monitoring.git
       ref: {{ .Git.ref | default "master" }}
@@ -200,8 +274,8 @@ components:
       - if: {{ semver.CheckConstraint "< 6.1.0-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v20231216-52-ge64909c-go1.19
     routers:
-      - description: Started from v8.0.0
-        if: {{ semver.CheckConstraint ">= 8.0.0-0" .Release.version }}
+      - description: Started from v5.3.0
+        if: {{ semver.CheckConstraint ">= 5.3.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
         profile: [release]
@@ -218,226 +292,6 @@ components:
               - name: ng-monitoring-server
                 src:
                   path: bin/ng-monitoring-server
-          - name: "prometheus-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
-            files: # output files.
-              - name: ng-monitoring-server
-                src:
-                  path: bin/ng-monitoring-server
-              - name: prometheus # must be first.
-                src:
-                  type: http
-                  url: https://github.com/prometheus/prometheus/releases/download/v2.49.1/prometheus-2.49.1.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
-                  extract_inner_path: prometheus-2.49.1.{{ .Release.os }}-{{ .Release.arch }}
-                  extract: true
-              - name: prometheus/tidb.rules.yml
-                src:
-                  type: http
-                  url: 'https://raw.githubusercontent.com/pingcap/tidb/{{ .Git.ref }}/pkg/metrics/alertmanager/tidb.rules.yml'
-              - name: prometheus/pd.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/pd/{{ .Git.ref }}/metrics/alertmanager/pd.rules.yml"
-              - name: prometheus/tikv.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/tikv/tikv/{{ .Git.ref }}/metrics/alertmanager/tikv.rules.yml"
-              - name: prometheus/tikv.accelerate.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/tikv/tikv/{{ .Git.ref }}/metrics/alertmanager/tikv.accelerate.rules.yml"
-              - name: prometheus/binlog.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tidb-binlog/{{ .Git.ref }}/metrics/alertmanager/binlog.rules.yml"
-              - name: prometheus/ticdc.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tiflow/{{ .Git.ref }}/metrics/alertmanager/ticdc.rules.yml"
-              - name: prometheus/tiflash.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tiflash/{{ .Git.ref }}/metrics/alertmanager/tiflash.rules.yml"
-              - name: prometheus/lightning.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tidb/{{ .Git.ref }}/br/metrics/alertmanager/lightning.rules.yml"
-              - name: prometheus/tiproxy.rules.yml
-                src:
-                  type: http
-                  # TODO: support building from tag.
-                  url: https://raw.githubusercontent.com/pingcap/monitoring/{{ .Git.ref }}/monitor-snapshot/{{ .Git.ref }}/operator/rules/tiproxy.rules.yml
-              - name: prometheus/blacker.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/{{ .Git.ref }}/platform-monitoring/ansible/rule/blacker.rules.yml"
-              - name: prometheus/bypass.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/{{ .Git.ref }}/platform-monitoring/ansible/rule/bypass.rules.yml"
-              - name: prometheus/kafka.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/{{ .Git.ref }}/platform-monitoring/ansible/rule/kafka.rules.yml"
-              - name: prometheus/node.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/{{ .Git.ref }}/platform-monitoring/ansible/rule/node.rules.yml"
-            tiup:
-              description: The Prometheus monitoring system and time series database
-              entrypoint: prometheus/prometheus
-      - description: Started from v5.3.0, until v8.0.0
-        if: {{ semver.CheckConstraint ">= 5.3.0-0, < 8.0.0-0" .Release.version }}
-        os: [linux, darwin]
-        arch: [amd64, arm64]
-        profile: [release]
-        steps:
-          release:
-            - script: make default
-        artifacts:
-          - name: container image
-            type: image
-            artifactory:
-              repo: hub.pingcap.net/pingcap/ng-monitoring/image
-            dockerfile: https://github.com/PingCAP-QE/artifacts/raw/main/dockerfiles/products/ng-monitoring.Dockerfile
-            files:
-              - name: ng-monitoring-server
-                src:
-                  path: bin/ng-monitoring-server
-          - name: "prometheus-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
-            files: # output files.
-              - name: ng-monitoring-server
-                src:
-                  path: bin/ng-monitoring-server
-              - name: prometheus # must be first.
-                src:
-                  type: http
-                  {{- if and (eq .Release.os "darwin") (eq .Release.arch "arm64") }}
-                  url: https://download.pingcap.org/prometheus-2.28.1.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
-                  extract_inner_path: prometheus-2.28.1.{{ .Release.os }}-{{ .Release.arch }}
-                  {{- else }}
-                  url: https://download.pingcap.org/prometheus-2.27.1.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
-                  extract_inner_path: prometheus-2.27.1.{{ .Release.os }}-{{ .Release.arch }}
-                  {{- end }}
-                  extract: true
-              - name: prometheus/tidb.rules.yml
-                src:
-                  type: http
-                  url: 'https://raw.githubusercontent.com/pingcap/tidb/{{ .Git.ref }}/{{ if semver.CheckConstraint "> 7.5.0-0" .Release.version }}pkg/{{ end }}metrics/alertmanager/tidb.rules.yml'
-              - name: prometheus/pd.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/pd/{{ .Git.ref }}/metrics/alertmanager/pd.rules.yml"
-              - name: prometheus/tikv.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/tikv/tikv/{{ .Git.ref }}/metrics/alertmanager/tikv.rules.yml"
-              - name: prometheus/tikv.accelerate.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/tikv/tikv/{{ .Git.ref }}/metrics/alertmanager/tikv.accelerate.rules.yml"
-              - name: prometheus/binlog.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tidb-binlog/{{ .Git.ref }}/metrics/alertmanager/binlog.rules.yml"
-              - name: prometheus/ticdc.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tiflow/{{ .Git.ref }}/metrics/alertmanager/ticdc.rules.yml"
-              - name: prometheus/tiflash.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tiflash/{{ .Git.ref }}/metrics/alertmanager/tiflash.rules.yml"
-              - name: prometheus/lightning.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tidb/{{ .Git.ref }}/br/metrics/alertmanager/lightning.rules.yml"
-              - name: prometheus/blacker.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/blacker.rules.yml"
-              - name: prometheus/bypass.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/bypass.rules.yml"
-              - name: prometheus/kafka.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/kafka.rules.yml"
-              - name: prometheus/node.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/node.rules.yml"
-            tiup:
-              description: The Prometheus monitoring system and time series database
-              entrypoint: prometheus/prometheus
-      - description: For v5.2.x
-        if: {{ semver.CheckConstraint "~5.2.0-0" .Release.version }}
-        os: [linux]
-        arch: [amd64, arm64]
-        profile: [release]
-        steps:
-          release: []
-        artifacts:
-          - name: "prometheus-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
-            files: # output files.
-              - name: prometheus
-                src:
-                  type: http
-                  url: https://download.pingcap.org/prometheus-2.8.1.{{ .Release.os }}-{{ .Release.arch }}.tar.gz
-                  extract: true
-                  extract_inner_path: prometheus-2.8.1.{{ .Release.os }}-{{ .Release.arch }}
-              - name: prometheus/tidb.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tidb/{{ .Git.ref }}/metrics/alertmanager/tidb.rules.yml"
-              - name: prometheus/pd.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/pd/{{ .Git.ref }}/metrics/alertmanager/pd.rules.yml"
-              - name: prometheus/tikv.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/tikv/tikv/{{ .Git.ref }}/metrics/alertmanager/tikv.rules.yml"
-              - name: prometheus/tikv.accelerate.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/tikv/tikv/{{ .Git.ref }}/metrics/alertmanager/tikv.accelerate.rules.yml"
-              - name: prometheus/binlog.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tidb-binlog/{{ .Git.ref }}/metrics/alertmanager/binlog.rules.yml"
-              - name: prometheus/ticdc.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tiflow/{{ .Git.ref }}/metrics/alertmanager/ticdc.rules.yml"
-              - name: prometheus/tiflash.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/tiflash/{{ .Git.ref }}/metrics/alertmanager/tiflash.rules.yml"
-              - name: prometheus/lightning.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/br/{{ .Git.ref }}/metrics/alertmanager/lightning.rules.yml"
-              - name: prometheus/blacker.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/blacker.rules.yml"
-                  path: blacker.rules.yml
-              - name: prometheus/bypass.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/bypass.rules.yml"
-              - name: prometheus/kafka.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/kafka.rules.yml"
-              - name: prometheus/node.rules.yml
-                src:
-                  type: http
-                  url: "https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/node.rules.yml"
-            tiup:
-              description: The Prometheus monitoring system and time series database
-              entrypoint: prometheus/prometheus
       - description: For v6.5.6 to v6.5.x fips profile
         if: {{ semver.CheckConstraint "~6.5.6-0" .Release.version }}
         os: [linux]
@@ -449,17 +303,17 @@ components:
           release:
             - script: make default
         artifacts:
-          - name: "ng-monitoring-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
-            files: # output files.
-              - name: ng-monitoring-server
-                src:
-                  path: bin/ng-monitoring-server
-          - name: fips container image
+          - name: container image
             type: image
             artifactory:
               repo: hub.pingcap.net/pingcap/ng-monitoring/image
             dockerfile: https://github.com/PingCAP-QE/artifacts/raw/main/dockerfiles/products/ng-monitoring.Dockerfile
             files:
+              - name: ng-monitoring-server
+                src:
+                  path: bin/ng-monitoring-server
+          - name: "ng-monitoring-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files: # output files.
               - name: ng-monitoring-server
                 src:
                   path: bin/ng-monitoring-server

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -163,11 +163,11 @@ components:
               description: Grafana is the open source analytics & monitoring solution for every database
               entrypoint: bin/grafana-server
           - name: "prometheus-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
-            files: # output files.
+            files:
               - name: ng-monitoring-server
                 src:
                   path: ng-monitoring/bin/ng-monitoring-server
-              - name: prometheus # must be first.
+              - name: prometheus
                 src:
                   path: output/prometheus
             tiup:
@@ -180,9 +180,10 @@ components:
         profile: [release]
         steps:
           release:
-            - script: >-
+            - script: |-
                 export TARGET={{ .Git.ref }}
-                export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}            
+                export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}
+                # TODO(lijie0123): please backport to 6.x LTS versions.
                 go run ./cmd/monitoring.go --config=monitoring.yaml --tag={{ .Git.ref }}
                 make default -C ng-monitoring
                 make output/prometheus
@@ -213,7 +214,7 @@ components:
           release:
             - script: |-
                 export TARGET={{ .Git.ref }}
-                export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}                
+                export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}
                 go run ./cmd/monitoring.go --config=monitoring.yaml --tag={{ .Git.ref }}
                 make default -C ng-monitoring
                 make output/prometheus
@@ -238,7 +239,7 @@ components:
           release:
             - script: |-
                 export TARGET={{ .Git.ref }}
-                export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}                
+                export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}
                 go run ./cmd/monitoring.go --config=monitoring.yaml --tag={{ .Git.ref }}
                 make output/prometheus
         artifacts:

--- a/packages/scripts/ci.sh
+++ b/packages/scripts/ci.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 function test_get_builder() {
-    local versions="v7.5.0 v7.1.0 v6.5.0"
+    local versions="v8.0.0 v7.5.0 v7.1.0 v6.5.0"
     local components="tidb tiflow tiflash tikv pd ctl monitoring ng-monitoring tidb-binlog tidb-tools"
     local operating_systems="linux darwin"
     local architectures="amd64 arm64"
@@ -41,7 +41,7 @@ function test_get_builder() {
             $script $cm $os $ac $version $profile
         done
     done
-     # tiflow-operator
+    # tiflow-operator
     local cm="tiflow-operator"
     local os="linux"
     for ac in $architectures; do
@@ -73,7 +73,7 @@ function test_get_builder() {
 }
 
 function test_gen_package_artifacts_script() {
-    local versions="v7.5.0 v7.1.0 v6.5.0"
+    local versions="v8.0.0 v7.5.0 v7.1.0 v6.5.0"
     local components="tidb tiflow tiflash tikv pd ctl monitoring ng-monitoring tidb-binlog tidb-tools"
     local operating_systems="linux darwin"
     local architectures="amd64 arm64"
@@ -86,6 +86,7 @@ function test_gen_package_artifacts_script() {
                 for ac in $architectures; do
                     echo "$cm $os $ac $version:"
                     $script $cm $os $ac $version $profile branch-xxx 123456789abcdef
+                    shellcheck -S error packages/scripts/build-package-artifacts.sh
                 done
             done
         done
@@ -98,6 +99,7 @@ function test_gen_package_artifacts_script() {
             for ac in $architectures; do
                 echo "$cm $os $ac $version:"
                 $script $cm $os $ac $version $profile branch-xxx 123456789abcdef
+                shellcheck -S error packages/scripts/build-package-artifacts.sh
             done
         done
     done
@@ -110,6 +112,7 @@ function test_gen_package_artifacts_script() {
         for version in v1.5.0 v1.6.0; do
             echo "$cm $os $ac $version:"
             $script $cm $os $ac $version $profile branch-xxx 123456789abcdef
+            shellcheck -S error packages/scripts/build-package-artifacts.sh
         done
     done
 
@@ -120,6 +123,7 @@ function test_gen_package_artifacts_script() {
         for version in v6.4.0-20221102-1667359250 v20221018; do
             echo "$cm $os $ac $version:"
             $script $cm $os $ac $version $profile branch-xxx 123456789abcdef
+            shellcheck -S error packages/scripts/build-package-artifacts.sh
         done
     done
 
@@ -130,6 +134,7 @@ function test_gen_package_artifacts_script() {
         for version in v0.5.0 v0.6.0; do
             echo "$cm $os $ac $version:"
             $script $cm $os $ac $version $profile branch-xxx 123456789abcdef
+            shellcheck -S error packages/scripts/build-package-artifacts.sh
         done
     done
 
@@ -140,12 +145,13 @@ function test_gen_package_artifacts_script() {
         for version in v0.1.2 v0.1.3; do
             echo "$cm $os $ac $version:"
             $script $cm $os $ac $version $profile branch-xxx 123456789abcdef
+            shellcheck -S error packages/scripts/build-package-artifacts.sh
         done
     done
 }
 
 function test_gen_package_images_script() {
-    local versions="v7.5.0 v7.1.0 v6.5.0"
+    local versions="v8.0.0 v7.5.0 v7.1.0 v6.5.0"
     local components="tidb tiflow tiflash tikv pd ctl monitoring ng-monitoring tidb-binlog tidb-tools"
     local architectures="amd64 arm64"
     local profile="release"
@@ -156,6 +162,7 @@ function test_gen_package_images_script() {
             for ac in $architectures; do
                 echo "$cm $os $ac $version:"
                 $script $cm linux $ac $version $profile branch-xxx 123456789abcdef
+                shellcheck -S error packages/scripts/build-package-images.sh
             done
         done
     done
@@ -166,6 +173,7 @@ function test_gen_package_images_script() {
         for ac in $architectures; do
             echo "$cm $os $ac $version:"
             $script $cm linux $ac $version $profile branch-xxx 123456789abcdef
+            shellcheck -S error packages/scripts/build-package-images.sh
         done
     done
 
@@ -177,6 +185,7 @@ function test_gen_package_images_script() {
         for version in v1.6.0 v1.5.0; do
             echo "$cm $os $ac $version:"
             $script $cm linux $ac $version $profile branch-xxx 123456789abcdef
+            shellcheck -S error packages/scripts/build-package-images.sh
         done
     done
     # tiflow-operator
@@ -186,6 +195,7 @@ function test_gen_package_images_script() {
         for version in v6.4.0-20221102-1667359250 v20221018; do
             echo "$cm $os $ac $version:"
             $script $cm linux $ac $version $profile branch-xxx 123456789abcdef
+            shellcheck -S error packages/scripts/build-package-images.sh
         done
     done
 
@@ -196,6 +206,7 @@ function test_gen_package_images_script() {
         for ac in $architectures; do
             echo "$cm $os $ac $version:"
             $script $cm linux $ac $version $profile branch-xxx 123456789abcdef
+            shellcheck -S error packages/scripts/build-package-images.sh
         done
     done
 
@@ -206,12 +217,13 @@ function test_gen_package_images_script() {
         for version in v0.1.2 v0.1.3; do
             echo "$cm $os $ac $version:"
             $script $cm linux $ac $version $profile branch-xxx 123456789abcdef
+            shellcheck -S error packages/scripts/build-package-images.sh
         done
     done
 }
 
 function test_gen_offline_package_artifacts_script() {
-    local versions="v7.5.0 v7.1.0"
+    local versions="v8.0.0 v7.5.0 v7.1.0"
     local operating_systems="linux"
     local architectures="amd64 arm64"
     local editions="community"
@@ -223,10 +235,18 @@ function test_gen_offline_package_artifacts_script() {
                 for edition in $editions; do
                     echo "$os $ac $version $edition:"
                     $script $os $ac $version $edition
+                    shellcheck -S error packages/scripts/compose-offline-packages-artifacts.sh
                 done
             done
         done
     done
+}
+
+function pre_checks() {
+    which shellcheck || (
+        echo "The script need 'shellcheck' tool, please install it!"
+        exit 1
+    )
 }
 
 function main() {

--- a/packages/scripts/ci.sh
+++ b/packages/scripts/ci.sh
@@ -250,6 +250,8 @@ function pre_checks() {
 }
 
 function main() {
+    pre_checks
+
     echo ">>>>>>>> test_get_builder >>>>>>>>>>>>>>>>>>>>>>>>"
     test_get_builder
     echo "<<<<<<<< test_get_builder <<<<<<<<<<<<<<<<<<<<<<<<"


### PR DESCRIPTION
As we have talked and decided internally:
1. most file is same as monitoring.
2. manager granfa and prometheus versions from `pingcap/monitoring` engineering.
3. ng-monitoring is a more standalone project, in future it will splited from "prometheus" tiup pkg.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>