### PR TITLE
feat(pingcap/monitoring): support build for tag creating triggers

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -144,8 +144,8 @@ components:
         profile: [release]
         steps:
           release:
-            - script: |-
-                export TARGET={{ .Git.ref }}
+            - script: |-                
+                export TARGET={{ if strings.HasPrefix "v" .Git.ref }}{{ printf "release-%d.%d" (semver.Semver .Git.ref).Major (semver.Semver .Git.ref).Minor }}{{ else }}{{ .Git.ref }}{{ end }}
                 export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}
                 make grafana_without_pull
                 make default -C ng-monitoring
@@ -181,7 +181,7 @@ components:
         steps:
           release:
             - script: |-
-                export TARGET={{ .Git.ref }}
+                export TARGET={{ if strings.HasPrefix "v" .Git.ref }}{{ printf "release-%d.%d" (semver.Semver .Git.ref).Major (semver.Semver .Git.ref).Minor }}{{ else }}{{ .Git.ref }}{{ end }}
                 export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}
                 go run ./cmd/monitoring.go --config=monitoring.yaml --tag={{ .Git.ref }}
                 make default -C ng-monitoring
@@ -206,7 +206,7 @@ components:
         steps:
           release:
             - script: |-
-                export TARGET={{ .Git.ref }}
+                export TARGET={{ if strings.HasPrefix "v" .Git.ref }}{{ printf "release-%d.%d" (semver.Semver .Git.ref).Major (semver.Semver .Git.ref).Minor }}{{ else }}{{ .Git.ref }}{{ end }}
                 export TARGET_OS={{ .Release.os }} TARGET_ARCH={{ .Release.arch }}
                 go run ./cmd/monitoring.go --config=monitoring.yaml --tag={{ .Git.ref }}
                 make output/prometheus


### PR DESCRIPTION
For example:
run: "./packages/scripts/gen-package-artifacts-with-config.sh monitoring darwin amd64 v7.1.1 release v8.0.0 ''"
output:
```bash
function build() {
    export TARGET=release-8.0
    export TARGET_OS=darwin TARGET_ARCH=amd64
    make grafana_without_pull
    make default -C ng-monitoring
    make output/prometheus
    echo "building finished."
}
```

Signed-off-by: wuhuizuo <wuhuizuo@126.com>