### PR TITLE
feat: support sync enterprise image

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -12,6 +12,12 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/tidb
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^(v[0-9]+[.][0-9]+[.][0-9])+-enterprise-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/tidb-enterprise
+      tag_regex_replace: "$1-pre"
   hub.pingcap.net/pingcap/tidb/images/br:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
@@ -24,6 +30,11 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/br
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/br-enterprise
   hub.pingcap.net/pingcap/tidb/images/tidb-lightning:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
@@ -33,6 +44,11 @@ image_copy_rules:
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
+        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/tidb-lightning
+    - description: delivery the enterprise RC images.
+      tags_regex:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/tidb-lightning
@@ -48,6 +64,11 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/dumpling
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/dumpling-enterprise
   hub.pingcap.net/pingcap/tiflow/images/cdc:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
@@ -60,6 +81,11 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/ticdc
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/ticdc-enterprise
   hub.pingcap.net/pingcap/tiflow/images/dm:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
@@ -72,6 +98,11 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/dm
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/dm-enterprise
   hub.pingcap.net/pingcap/tiflow/images/tiflow:
     - description: delivery the trunk branch extractly images.
       tags_regex:
@@ -96,6 +127,12 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/tiflash
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^(v[0-9]+[.][0-9]+[.][0-9])+-enterprise-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/tiflash-enterprise
+      tag_regex_replace: "$1-pre"
   hub.pingcap.net/pingcap/tiproxy/image:
     - description: publish trunk and version images.
       tags_regex:
@@ -115,6 +152,11 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/tidb-monitor-initializer
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/tidb-monitor-initializer-enterprise
   hub.pingcap.net/pingcap/ng-monitoring/image:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
@@ -127,6 +169,11 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/ng-monitoring
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/ng-monitoring-enterprise
   hub.pingcap.net/pingcap/tidb-tools/image:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
@@ -145,6 +192,11 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/tidb-binlog
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/tidb-binlog-enterprise
   hub.pingcap.net/tikv/tikv/image:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
@@ -157,6 +209,12 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/tikv
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^(v[0-9]+[.][0-9]+[.][0-9])+-enterprise-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/tikv-enterprise
+      tag_regex_replace: "$1-pre"
   hub.pingcap.net/tikv/pd/image:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
@@ -169,6 +227,12 @@ image_copy_rules:
         - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
       dest_repositories:
         - hub.pingcap.net/qa/pd
+    - description: delivery the enterprise RC images.
+      tags_regex:
+        - ^(v[0-9]+[.][0-9]+[.][0-9])+-enterprise-pre$
+      dest_repositories:
+        - hub.pingcap.net/qa/pd-enterprise
+      tag_regex_replace: "$1-pre"
   hub.pingcap.net/pingcap/tiflow-operator/image:
     - description: delivery the trunk branch extractly images.
       tags_regex:

--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -14,10 +14,10 @@ image_copy_rules:
         - hub.pingcap.net/qa/tidb
     - description: delivery the enterprise RC images.
       tags_regex:
-        - ^(v[0-9]+[.][0-9]+[.][0-9])+-enterprise-pre$
+        - ^(v[0-9]+[.][0-9]+[.][0-9]+-pre)-enterprise$
       dest_repositories:
         - hub.pingcap.net/qa/tidb-enterprise
-      tag_regex_replace: "$1-pre"
+      tag_regex_replace: "$1"
   hub.pingcap.net/pingcap/tidb/images/br:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
@@ -129,10 +129,10 @@ image_copy_rules:
         - hub.pingcap.net/qa/tiflash
     - description: delivery the enterprise RC images.
       tags_regex:
-        - ^(v[0-9]+[.][0-9]+[.][0-9])+-enterprise-pre$
+        - ^(v[0-9]+[.][0-9]+[.][0-9]+-pre)-enterprise$
       dest_repositories:
         - hub.pingcap.net/qa/tiflash-enterprise
-      tag_regex_replace: "$1-pre"
+      tag_regex_replace: "$1"
   hub.pingcap.net/pingcap/tiproxy/image:
     - description: publish trunk and version images.
       tags_regex:
@@ -211,10 +211,10 @@ image_copy_rules:
         - hub.pingcap.net/qa/tikv
     - description: delivery the enterprise RC images.
       tags_regex:
-        - ^(v[0-9]+[.][0-9]+[.][0-9])+-enterprise-pre$
+        - ^(v[0-9]+[.][0-9]+[.][0-9]+-pre)-enterprise$
       dest_repositories:
         - hub.pingcap.net/qa/tikv-enterprise
-      tag_regex_replace: "$1-pre"
+      tag_regex_replace: "$1"
   hub.pingcap.net/tikv/pd/image:
     - description: delivery the trunk branch images.
       tags_regex: [^master$]
@@ -229,10 +229,10 @@ image_copy_rules:
         - hub.pingcap.net/qa/pd
     - description: delivery the enterprise RC images.
       tags_regex:
-        - ^(v[0-9]+[.][0-9]+[.][0-9])+-enterprise-pre$
+        - ^(v[0-9]+[.][0-9]+[.][0-9]+-pre)-enterprise$
       dest_repositories:
         - hub.pingcap.net/qa/pd-enterprise
-      tag_regex_replace: "$1-pre"
+      tag_regex_replace: "$1"
   hub.pingcap.net/pingcap/tiflow-operator/image:
     - description: delivery the trunk branch extractly images.
       tags_regex:

--- a/packages/scripts/gen-delivery-image-commands.ts
+++ b/packages/scripts/gen-delivery-image-commands.ts
@@ -61,6 +61,7 @@ async function generateShellScript(
         ),
       );
       for (const constTag of constant_tags) {
+        console.log(`\tAdditional tag: ${constTag}`)
         await file.write(
           new TextEncoder().encode(
             `crane tag ${destRepo}:${tag} ${constTag}\n`,
@@ -68,7 +69,8 @@ async function generateShellScript(
         );
       }
       if (tag_regex_replace!=""){
-        let converted = tag.replace(new RegExp(tags_regex[0]), tag_regex_replace)
+        const converted = tag.replace(new RegExp(tags_regex[0]), tag_regex_replace)
+        console.log(`\tAdditional tag: ${converted}`)
         await file.write(
           new TextEncoder().encode(
             `crane tag ${destRepo}:${tag} ${converted}\n`,

--- a/packages/scripts/gen-delivery-image-commands.ts
+++ b/packages/scripts/gen-delivery-image-commands.ts
@@ -6,6 +6,7 @@ interface Rule {
   tags_regex: string[];
   dest_repositories: string[];
   constant_tags?: string[];
+  tag_regex_replace?: string
 }
 
 interface Config {
@@ -43,7 +44,7 @@ async function generateShellScript(
 
   // Loop through rules
   for (const rule of rules) {
-    const { description = "", dest_repositories, constant_tags = [] } = rule;
+    const { description = "", dest_repositories, constant_tags = [], tag_regex_replace = "", tags_regex=[] } = rule;
 
     console.log(
       `Matching rule found for image URL '${imageUrlWithTag}':`,
@@ -63,6 +64,14 @@ async function generateShellScript(
         await file.write(
           new TextEncoder().encode(
             `crane tag ${destRepo}:${tag} ${constTag}\n`,
+          ),
+        );
+      }
+      if (tag_regex_replace!=""){
+        let converted = tag.replace(new RegExp(tags_regex[0]), tag_regex_replace)
+        await file.write(
+          new TextEncoder().encode(
+            `crane tag ${destRepo}:${tag} ${converted}\n`,
           ),
         );
       }


### PR DESCRIPTION
# Why:
- for tidb/pd/tikv/tiflash: sync like:

`hub.pingcap.net/pingcap/tidb/images/tidb-server:v7.1.2-enterprise-pre -> hub.pingcap.net/qa/tidb-enterprise:v7.1.2-pre`
- for others: sync like:
`hub.pingcap.net/pingcap/tidb/images/br:v7.1.2-pre -> hub.pingcap.net/qa/br-enterprise:v7.1.2-pre`

#How:
- add tag_regex_replace to remove enterprise tag