### PR TITLE
fix(pingcap/ng-monitoring): fix image building

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -272,6 +272,11 @@ components:
               - name: ng-monitoring-server
                 src:
                   path: bin/ng-monitoring-server
+          - name: "binaries-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files: # output files.
+              - name: ng-monitoring-server
+                src:
+                  path: bin/ng-monitoring-server
       - description: For v6.5.6 to v6.5.x fips profile
         if: {{ semver.CheckConstraint "~6.5.6-0" .Release.version }}
         os: [linux]
@@ -292,7 +297,7 @@ components:
               - name: ng-monitoring-server
                 src:
                   path: bin/ng-monitoring-server
-          - name: "ng-monitoring-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+          - name: "binaries-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
             files: # output files.
               - name: ng-monitoring-server
                 src:


### PR DESCRIPTION
Must have artifacts when image building need pre-compiled binaries.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>