### PR TITLE
opt(packages): abstract the delivery tag regexes

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -4,49 +4,58 @@ definitions:
     description: delivery the trunk branch images.
     tags_regex: [^master$]
     constant_tags: [nightly] # add new tags.
+  sync_trunk_enterprise: &sync_trunk_enterprise {}
   sync_rc_community: &sync_rc_community
-  sync_ga_community: &sync_ga_community
-  sync_trunk_enterprise: &sync_trunk_enterprise
-    {}
+    description: delivery community images for release branches.
+    tags_regex:
+      - ^release-[0-9]+[.][0-9]+$
+      - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+  sync_rc_community_and_failpoint: &sync_rc_community_and_failpoint
+    description: delivery community and failpoint images for release branches.
+    tags_regex:
+      - ^release-[0-9]+[.][0-9]+$
+      - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+      - ^release-[0-9]+[.][0-9]+-failpoint$
+      - ^v[0-9]+[.][0-9]+[.][0-9]+-pre-failpoint$
   sync_rc_enterprise: &sync_rc_enterprise
-    {}
+    description: delivery the enterprise RC images.
+    tags_regex:
+      - ^(v[0-9]+[.][0-9]+[.][0-9]+-pre)-enterprise$
+    tag_regex_replace: "$1"
+  sync_rc_community_to_enterprise_repo: &sync_rc_community_to_enterprise_repo
+    description: delivery the community image to enterprise repos.
+    tags_regex:
+      - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+  sync_ga_community: &sync_ga_community
+    description: delivery community images for GA images.
+    tags_regex:
+      - ^v[0-9]+[.][0-9]+[.][0-9]+$
   sync_ga_enterprise: &sync_ga_enterprise
-    {}
-
+    description: delivery the enterprise GA images.
+    tags_regex:
+      - ^(v[0-9]+[.][0-9]+[.][0-9]+)-enterprise$
+    tag_regex_replace: "$1"
 image_copy_rules:
   hub.pingcap.net/pingcap/tidb/images/tidb-server:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tidb
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
-        - ^release-[0-9]+[.][0-9]+-failpoint$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre-failpoint$
+    - <<: *sync_rc_community_and_failpoint
       dest_repositories:
         - hub.pingcap.net/qa/tidb
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^(v[0-9]+[.][0-9]+[.][0-9]+-pre)-enterprise$
+    - <<: *sync_rc_enterprise
       dest_repositories:
         - hub.pingcap.net/qa/tidb-enterprise
         - gcr.io/pingcap-public/dbaas/tidb
-      tag_regex_replace: "$1"
   hub.pingcap.net/pingcap/tidb/images/br:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/br
       constant_tags: [nightly]
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/br
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community_to_enterprise_repo
       dest_repositories:
         - hub.pingcap.net/qa/br-enterprise
         - gcr.io/pingcap-public/dbaas/br
@@ -54,15 +63,10 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tidb-lightning
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/tidb-lightning
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community_to_enterprise_repo
       dest_repositories:
         - hub.pingcap.net/qa/tidb-lightning-enterprise
         - gcr.io/pingcap-public/dbaas/tidb-lightning
@@ -70,15 +74,10 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/dumpling
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/dumpling
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community_to_enterprise_repo
       dest_repositories:
         - hub.pingcap.net/qa/dumpling-enterprise
         - gcr.io/pingcap-public/dbaas/dumpling
@@ -86,15 +85,10 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/ticdc
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/ticdc
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community_to_enterprise_repo
       dest_repositories:
         - hub.pingcap.net/qa/ticdc-enterprise
         - gcr.io/pingcap-public/dbaas/ticdc
@@ -102,15 +96,10 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/dm
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/dm
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community_to_enterprise_repo
       dest_repositories:
         - hub.pingcap.net/qa/dm-enterprise
         - gcr.io/pingcap-public/dbaas/dm
@@ -128,19 +117,13 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tiflash
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/tiflash
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^(v[0-9]+[.][0-9]+[.][0-9]+-pre)-enterprise$
+    - <<: *sync_rc_enterprise
       dest_repositories:
         - hub.pingcap.net/qa/tiflash-enterprise
         - gcr.io/pingcap-public/dbaas/tiflash
-      tag_regex_replace: "$1"
   hub.pingcap.net/pingcap/tiproxy/image:
     - description: publish trunk and version images.
       tags_regex:
@@ -152,15 +135,10 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tidb-monitor-initializer
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/tidb-monitor-initializer
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community_to_enterprise_repo
       dest_repositories:
         - hub.pingcap.net/qa/tidb-monitor-initializer-enterprise
         - gcr.io/pingcap-public/dbaas/tidb-monitor-initializer
@@ -168,15 +146,10 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/ng-monitoring
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/ng-monitoring
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community_to_enterprise_repo
       dest_repositories:
         - hub.pingcap.net/qa/ng-monitoring-enterprise
         - gcr.io/pingcap-public/dbaas/ng-monitoring
@@ -188,15 +161,10 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tidb-binlog
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/tidb-binlog
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community_to_enterprise_repo
       dest_repositories:
         - hub.pingcap.net/qa/tidb-binlog-enterprise
         - gcr.io/pingcap-public/dbaas/tidb-binlog
@@ -204,40 +172,24 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tikv
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
-        - ^release-[0-9]+[.][0-9]+-failpoint$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre-failpoint$
+    - <<: *sync_rc_community_and_failpoint
       dest_repositories:
         - hub.pingcap.net/qa/tikv
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^(v[0-9]+[.][0-9]+[.][0-9]+-pre)-enterprise$
+    - <<: *sync_rc_enterprise
       dest_repositories:
         - hub.pingcap.net/qa/tikv-enterprise
         - gcr.io/pingcap-public/dbaas/tikv
-      tag_regex_replace: "$1"
   hub.pingcap.net/tikv/pd/image:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/pd
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
-        - ^release-[0-9]+[.][0-9]+-failpoint$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre-failpoint$
+    - <<: *sync_rc_community_and_failpoint
       dest_repositories:
         - hub.pingcap.net/qa/pd
-    - description: delivery the enterprise RC images.
-      tags_regex:
-        - ^(v[0-9]+[.][0-9]+[.][0-9]+-pre)-enterprise$
+    - <<: *sync_rc_enterprise
       dest_repositories:
         - hub.pingcap.net/qa/pd-enterprise
         - gcr.io/pingcap-public/dbaas/pd
-      tag_regex_replace: "$1"
   hub.pingcap.net/pingcap/tiflow-operator/image:
     - description: delivery the trunk branch extractly images.
       tags_regex:
@@ -247,13 +199,11 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - gcr.io/pingcap-public/tidbcloud/tiflow-operator
+      constant_tags: [latest]
   hub.pingcap.net/pingcap/tidb-dashboard/image:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tidb-dashboard
-    - description: delivery the release branch images.
-      tags_regex:
-        - ^release-[0-9]+[.][0-9]+$
-        - ^v[0-9]+[.][0-9]+[.][0-9]+-pre$
+    - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/tidb-dashboard

--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -1,11 +1,23 @@
 # yaml-language-server: $schema=./delivery-schema.json
+definitions:
+  sync_trunk_community: &sync_trunk_community
+    description: delivery the trunk branch images.
+    tags_regex: [^master$]
+    constant_tags: [nightly] # add new tags.
+  sync_rc_community: &sync_rc_community
+  sync_ga_community: &sync_ga_community
+  sync_trunk_enterprise: &sync_trunk_enterprise
+    {}
+  sync_rc_enterprise: &sync_rc_enterprise
+    {}
+  sync_ga_enterprise: &sync_ga_enterprise
+    {}
+
 image_copy_rules:
   hub.pingcap.net/pingcap/tidb/images/tidb-server:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
-      dest_repositories: # full repo url
+    - <<: *sync_trunk_community
+      dest_repositories:
         - docker.io/pingcap/tidb
-      constant_tags: [nightly] # add new tags.
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -22,8 +34,7 @@ image_copy_rules:
         - gcr.io/pingcap-public/dbaas/tidb
       tag_regex_replace: "$1"
   hub.pingcap.net/pingcap/tidb/images/br:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/br
       constant_tags: [nightly]
@@ -40,11 +51,9 @@ image_copy_rules:
         - hub.pingcap.net/qa/br-enterprise
         - gcr.io/pingcap-public/dbaas/br
   hub.pingcap.net/pingcap/tidb/images/tidb-lightning:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tidb-lightning
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -58,11 +67,9 @@ image_copy_rules:
         - hub.pingcap.net/qa/tidb-lightning-enterprise
         - gcr.io/pingcap-public/dbaas/tidb-lightning
   hub.pingcap.net/pingcap/tidb/images/dumpling:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/dumpling
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -76,11 +83,9 @@ image_copy_rules:
         - hub.pingcap.net/qa/dumpling-enterprise
         - gcr.io/pingcap-public/dbaas/dumpling
   hub.pingcap.net/pingcap/tiflow/images/cdc:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/ticdc
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -94,11 +99,9 @@ image_copy_rules:
         - hub.pingcap.net/qa/ticdc-enterprise
         - gcr.io/pingcap-public/dbaas/ticdc
   hub.pingcap.net/pingcap/tiflow/images/dm:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/dm
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -117,18 +120,14 @@ image_copy_rules:
         - ^master-[0-9a-f]+$
       dest_repositories:
         - gcr.io/pingcap-public/tidbcloud/tiflow
-    - description: delivery the trunk branch images.
-      tags_regex:
-        - ^master$
+    - <<: *sync_trunk_community
       dest_repositories:
         - gcr.io/pingcap-public/tidbcloud/tiflow
       constant_tags: [latest]
   hub.pingcap.net/pingcap/tiflash/image:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tiflash
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -150,11 +149,9 @@ image_copy_rules:
       dest_repositories:
         - docker.io/pingcap/tiproxy
   hub.pingcap.net/pingcap/monitoring/image:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tidb-monitor-initializer
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -168,11 +165,9 @@ image_copy_rules:
         - hub.pingcap.net/qa/tidb-monitor-initializer-enterprise
         - gcr.io/pingcap-public/dbaas/tidb-monitor-initializer
   hub.pingcap.net/pingcap/ng-monitoring/image:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/ng-monitoring
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -186,17 +181,13 @@ image_copy_rules:
         - hub.pingcap.net/qa/ng-monitoring-enterprise
         - gcr.io/pingcap-public/dbaas/ng-monitoring
   hub.pingcap.net/pingcap/tidb-tools/image:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tidb-tools
-      constant_tags: [nightly]
   hub.pingcap.net/pingcap/tidb-binlog/image:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tidb-binlog
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -210,11 +201,9 @@ image_copy_rules:
         - hub.pingcap.net/qa/tidb-binlog-enterprise
         - gcr.io/pingcap-public/dbaas/tidb-binlog
   hub.pingcap.net/tikv/tikv/image:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tikv
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -231,11 +220,9 @@ image_copy_rules:
         - gcr.io/pingcap-public/dbaas/tikv
       tag_regex_replace: "$1"
   hub.pingcap.net/tikv/pd/image:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/pd
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$
@@ -257,18 +244,13 @@ image_copy_rules:
         - ^master-[0-9a-f]+$
       dest_repositories:
         - gcr.io/pingcap-public/tidbcloud/tiflow-operator
-    - description: delivery the trunk branch images.
-      tags_regex:
-        - ^master$
+    - <<: *sync_trunk_community
       dest_repositories:
         - gcr.io/pingcap-public/tidbcloud/tiflow-operator
-      constant_tags: [latest]
   hub.pingcap.net/pingcap/tidb-dashboard/image:
-    - description: delivery the trunk branch images.
-      tags_regex: [^master$]
+    - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/tidb-dashboard
-      constant_tags: [nightly]
     - description: delivery the release branch images.
       tags_regex:
         - ^release-[0-9]+[.][0-9]+$

--- a/packages/scripts/pre-to-ga-tag.sh
+++ b/packages/scripts/pre-to-ga-tag.sh
@@ -16,8 +16,8 @@ function add_ga_tag_on_from_pre() {
     # package
     for repo in $(grep "^\s*package_repo:" ${PROJECT_ROOT_DIR}/packages/packages.yaml.tmpl | awk '{print $2}' | sort -u); do
         for platform in linux_amd64 linux_arm64 darwin_amd64 darwin_arm64; do
-            oras repo tags $repo:$rc_ver && {
-                oras tag $repo:$rc_ver $repo:$ga_ver
+            oras repo tags $repo:${rc_ver}_${platform} && {
+                oras tag $repo:${rc_ver}_${platform} $repo:${ga_ver}_${platform}
             }
         done
     done


### PR DESCRIPTION
why:
- improve maintainability and readability

Tested:

- ✅ diff with old and new with `yq --output-format json '.image_copy_rules ' packages/delivery.yaml`
