### PR TITLE
chore: auto bump git version by renovate

### DIFF
--- a/dockerfiles/ci/base/Dockerfile
+++ b/dockerfiles/ci/base/Dockerfile
@@ -89,6 +89,7 @@ RUN apt-get update && \
     zlib1g-dev \
     autoconf \
     dh-autoreconf
+# renovate: datasource=github-tags depName=git/git
 ARG GIT_VERSION=2.39.4
 RUN wget https://github.com/git/git/archive/refs/tags/v$GIT_VERSION.zip -O git.zip && \
     unzip git.zip && \

--- a/dockerfiles/ci/release-build-base/Dockerfile
+++ b/dockerfiles/ci/release-build-base/Dockerfile
@@ -131,6 +131,7 @@ RUN curl -sSL https://github.com/pingcap/tiflash/raw/${TIFLASH_TAG}/release-cent
     install_ccache ${CCACHE_VERSION}
 
 # Git, update to 2.40.2 to fix the security issue
+# renovate: datasource=github-tags depName=git/git
 ARG GIT_VERSION=2.40.2
 RUN wget https://github.com/git/git/archive/refs/tags/v$GIT_VERSION.zip -O git.zip && \
     unzip git.zip && \


### PR DESCRIPTION
auto bump git version by renovate