### PR TITLE
feat: tiflash use llvm17 to build on version >= 8.2

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1124,6 +1124,8 @@ components:
         - {{ strings.ReplaceAll "/" "-" .Git.ref | strings.ToLower }}
         - {{ .Release.version }}
     builders:
+      - if: {{ semver.CheckConstraint ">= 8.2.0-0" .Release.version }}
+        image: hub.pingcap.net/ee/ci/release-build-base-tiflash:v20240625-llvm-17.0.6
       - if: {{ semver.CheckConstraint ">= 6.1.0-0" .Release.version }}
         image: hub.pingcap.net/ee/ci/release-build-base-tiflash:v20231106
     routers:


### PR DESCRIPTION
tiflash use llvm17 to build on version >= 8.2