### PR TITLE
ci: temp disable build for tiflash builder image

### DIFF
--- a/.github/workflows/pull-cd-builder-images.yaml
+++ b/.github/workflows/pull-cd-builder-images.yaml
@@ -85,7 +85,8 @@ jobs:
 
     strategy:
       matrix:
-        module: [builder-others, builder-tikv, builder-tikv-fips, builder-others-slow]
+        # module: [builder-others, builder-tikv, builder-tikv-fips, builder-others-slow]
+        module: [builder-others, builder-tikv, builder-tikv-fips]
         platform: [linux/amd64, linux/arm64]
         builder-profile: [local-docker]
         include:

--- a/.github/workflows/release-cd-builder-images.yaml
+++ b/.github/workflows/release-cd-builder-images.yaml
@@ -77,7 +77,8 @@ jobs:
       packages: write
     strategy:
       matrix:
-        module: [builder-others, builder-tikv, builder-tikv-fips, builder-others-slow]
+        # module: [builder-others, builder-tikv, builder-tikv-fips, builder-others-slow]
+        module: [builder-others, builder-tikv, builder-tikv-fips]
         builder-profile: [local-docker]
         include:
           - module: builder-tikv


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>

We can revert it after https://github.com/pingcap/tiflash/pull/9178 be merged.