### PR TITLE
feat(packages): add image copy rule for tidb-operator

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -47,13 +47,19 @@ image_copy_rules:
       dest_repositories:
         - docker.io/pingcap/advanced-statefulset
         - gcr.io/pingcap-public/dbaas/advanced-statefulset
-  hub.pingcap.net/pingcap/tidb-operator/image:
+  hub.pingcap.net/pingcap/tidb-operator/image: &tidb-operator
     - description: delivery the version images.
       tags_regex:
+        - ^master$
         - ^(v[0-9]+[.][0-9]+[.][0-9]+)(-.+)?$
       dest_repositories:
         - docker.io/pingcap/tidb-operator
         - gcr.io/pingcap-public/dbaas/tidb-operator
+    - <<: *sync_trunk_community
+      dest_repositories:
+        - docker.io/pingcap/tidb-operator
+        - gcr.io/pingcap-public/dbaas/tidb-operator
+  hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator: *tidb-operator
   hub.pingcap.net/pingcap/tidb/images/tidb-server:
     - <<: *sync_trunk_community
       dest_repositories:

--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -50,7 +50,6 @@ image_copy_rules:
   hub.pingcap.net/pingcap/tidb-operator/image: &tidb-operator
     - description: delivery the version images.
       tags_regex:
-        - ^master$
         - ^(v[0-9]+[.][0-9]+[.][0-9]+)(-.+)?$
       dest_repositories:
         - docker.io/pingcap/tidb-operator


### PR DESCRIPTION
### **User description**
coping master tag to DockerHub.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new image copy rule for `tidb-operator` to include the `master` tag.
- Introduced a new rule using `sync_trunk_community` for `tidb-operator`.
- Updated destination repositories for the `tidb-operator` image.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>delivery.yaml</strong><dd><code>Add image copy rule for `tidb-operator` in delivery.yaml</code>&nbsp; </dd></summary>
<hr>

packages/delivery.yaml

<li>Added <code>master</code> tag to <code>tags_regex</code> for <code>tidb-operator</code> image copy rule.<br> <li> Introduced a new image copy rule for <code>tidb-operator</code> using <br><code>sync_trunk_community</code>.<br> <li> Updated destination repositories for <code>tidb-operator</code> image.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/artifacts/pull/346/files#diff-95b19687ffd73deffa23edebbb4b0a94ba865cb9c854c36a77281c93703822e6">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

