### PR TITLE
fix(deps): bump release utils images

### DIFF
--- a/dockerfiles/cd/utils/release/Dockerfile
+++ b/dockerfiles/cd/utils/release/Dockerfile
@@ -1,19 +1,15 @@
-FROM golang:1.22.5-alpine3.20 as gomplate_builder
-
-RUN wget https://github.com/hairyhenderson/gomplate/archive/refs/heads/main.zip -O - | unzip - && cd gomplate-main && go build -o /usr/local/bin/gomplate ./cmd/gomplate
-
 FROM alpine:3.20.1
 
 LABEL org.opencontainers.image.authors "wuhui.zuo@pingcap.com"
 LABEL org.opencontainers.image.description "utils image for CD release"
 LABEL org.opencontainers.image.source = "https://github.com/PingCAP-QE/artifacts"
 
-# install tools: bash, git, jq, yq, goemplate
+# install tools: bash, git, jq, yq
 # RUN apk add --no-cache bash git jq yq uuidgen gomplate
 RUN apk add --no-cache bash git jq yq uuidgen
 
-# install gomplate
-COPY --from=gomplate_builder --chown=0:0 /usr/local/bin/gomplate /usr/local/bin/gomplate
+# install tools: gomplate
+COPY --from=hairyhenderson/gomplate:v4.1.0-alpine /bin/gomplate /usr/local/bin/gomplate
 
 # install tools: oras
 COPY --from=ghcr.io/oras-project/oras:v1.2.0 --chown=0:0 /bin/oras /usr/local/bin/oras


### PR DESCRIPTION
### **User description**
Signed-off-by: wuhuizuo <wuhuizuo@126.com>


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated the Dockerfile to use a pre-built `gomplate` image from `hairyhenderson/gomplate:v4.1.0-alpine` instead of building it from source.
- Removed unnecessary steps and simplified the Dockerfile.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update `gomplate` installation to use pre-built image</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dockerfiles/cd/utils/release/Dockerfile

<li>Removed custom build process for <code>gomplate</code>.<br> <li> Updated to use pre-built <code>gomplate</code> image from <br><code>hairyhenderson/gomplate:v4.1.0-alpine</code>.<br> <li> Simplified Dockerfile by removing unnecessary steps.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/artifacts/pull/350/files#diff-5cbd88ab49628ca7ea97ce8761e581d89b92afeb36daa1079fe009b997f83422">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

