### PR TITLE
fix(dockerfiles/cd/utils/release): create required dir for tiup 

### DIFF
--- a/dockerfiles/cd/utils/release/Dockerfile
+++ b/dockerfiles/cd/utils/release/Dockerfile
@@ -32,4 +32,5 @@ RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
 ARG TIUP_VER=1.15.2
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
     wget -q -O - https://tiup-mirrors.pingcap.com/tiup-v${TIUP_VER}-${OS}-${ARCH}.tar.gz | tar -zxvf - -C /usr/local/bin && \
-    chmod 755 /usr/local/bin/tiup
+    chmod 755 /usr/local/bin/tiup && \
+    mkdir -p ~/.tiup/bin

--- a/dockerfiles/cd/utils/release/Dockerfile
+++ b/dockerfiles/cd/utils/release/Dockerfile
@@ -33,4 +33,4 @@ ARG TIUP_VER=1.15.2
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
     wget -q -O - https://tiup-mirrors.pingcap.com/tiup-v${TIUP_VER}-${OS}-${ARCH}.tar.gz | tar -zxvf - -C /usr/local/bin && \
     chmod 755 /usr/local/bin/tiup && \
-    mkdir -p ~/.tiup/bin
+    mkdir -p /root/.tiup/bin

--- a/dockerfiles/cd/utils/release/Dockerfile
+++ b/dockerfiles/cd/utils/release/Dockerfile
@@ -33,4 +33,4 @@ ARG TIUP_VER=1.15.2
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
     wget -q -O - https://tiup-mirrors.pingcap.com/tiup-v${TIUP_VER}-${OS}-${ARCH}.tar.gz | tar -zxvf - -C /usr/local/bin && \
     chmod 755 /usr/local/bin/tiup && \
-    mkdir -p /root/.tiup/bin
+    mkdir -p "$HOME/.tiup/bin"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue in the Dockerfile where the required directory for `tiup` was not being created.
- Added a command to ensure the `~/.tiup/bin` directory is created during the Docker build process.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Create required directory for `tiup` in Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dockerfiles/cd/utils/release/Dockerfile

<li>Added a command to create the required directory for <code>tiup</code>.<br> <li> Ensured the directory <code>~/.tiup/bin</code> is created during the Docker build <br>process.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/artifacts/pull/351/files#diff-5cbd88ab49628ca7ea97ce8761e581d89b92afeb36daa1079fe009b997f83422">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

