### PR TITLE
chore(deps): update ghcr.io/pingcap-qe/cd/utils/release docker tag to v20240325-60-gb6f8928

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -16,7 +16,7 @@ components:
         - {{ .Release.version }}
     builders:
       - if: {{ semver.CheckConstraint ">= 0.5.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/utils/release:v20240325-14-gdd4a4cf
+        image: ghcr.io/pingcap-qe/cd/utils/release:v20240325-60-gb6f8928
     routers:
       - description: Publish route for v0.5.0 and newer versions.
         if: {{ semver.CheckConstraint ">= 0.5.0-0" .Release.version }}
@@ -46,7 +46,7 @@ components:
         - {{ strings.ReplaceAll "/" "-" .Git.ref | strings.ToLower }}
         - {{ .Release.version }}
     builders:
-      - image: ghcr.io/pingcap-qe/cd/utils/release:v20240325-14-gdd4a4cf
+      - image: ghcr.io/pingcap-qe/cd/utils/release:v20240325-60-gb6f8928
     routers:
       - description: interpret versions according to semantic version spec.
         if: {{ semver.CheckConstraint ">= 6.1.0-0" .Release.version }}
@@ -1422,7 +1422,7 @@ components:
         - {{ strings.ReplaceAll "/" "-" .Git.ref | strings.ToLower }}
         - {{ .Release.version }}
     builders:
-      - image: ghcr.io/pingcap-qe/cd/utils/release:v20240325-14-gdd4a4cf
+      - image: ghcr.io/pingcap-qe/cd/utils/release:v20240325-60-gb6f8928
     routers:
       - description: interpret versions according to semantic version spec.
         os: [linux]


### PR DESCRIPTION
### **User description**
- bump to oras v1.2.0

Signed-off-by: wuhuizuo <wuhuizuo@126.com>


___

### **PR Type**
Enhancement


___

### **Description**
- Updated the Docker image tag for `ghcr.io/pingcap-qe/cd/utils/release` to `v20240325-60-gb6f8928` in `packages/packages.yaml.tmpl`.
- This update includes a bump to `oras` version `1.2.0`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>packages.yaml.tmpl</strong><dd><code>Update Docker image tag for release utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/packages.yaml.tmpl

<li>Updated the <code>image</code> tag for <code>ghcr.io/pingcap-qe/cd/utils/release</code> from <br><code>v20240325-14-gdd4a4cf</code> to <code>v20240325-60-gb6f8928</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/artifacts/pull/353/files#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

