### PR TITLE
chore(packages): remove arbiter from offline deployment packages

### DIFF
--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -843,7 +843,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
-                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
+                if: {{ semver.CheckConstraint "< 8.1.1-0 || >= 8.2.0-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"

--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -320,7 +320,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
-                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
+                if: {{ semver.CheckConstraint "< 8.1.1-0 || >= 8.2.0-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"

--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -426,7 +426,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
-                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
+                if: {{ semver.CheckConstraint "< 8.1.1-0 || >= 8.2.0-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"

--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -122,7 +122,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
-                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
+                if: {{ semver.CheckConstraint "< 8.1.1-0 || >= 8.2.0-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"

--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -985,7 +985,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
-                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
+                if: {{ semver.CheckConstraint "< 8.1.1-0 || >= 8.2.0-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"

--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -573,7 +573,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
-                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
+                if: {{ semver.CheckConstraint "< 8.1.1-0 || >= 8.2.0-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"

--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -220,7 +220,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
-                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
+                if: {{ semver.CheckConstraint "< 8.1.1-0 || >= 8.2.0-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"

--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -707,7 +707,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
-                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
+                if: {{ semver.CheckConstraint "< 8.1.1-0 || >= 8.2.0-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"

--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -122,6 +122,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
+                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"
@@ -219,6 +220,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
+                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"
@@ -318,6 +320,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
+                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"
@@ -423,6 +426,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
+                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"
@@ -569,6 +573,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
+                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"
@@ -702,6 +707,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
+                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"
@@ -837,6 +843,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
+                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"
@@ -978,6 +985,7 @@ editions:
                   extract: true
                   extract_inner_path: reparo
               - name: arbiter # New in v6.0.0
+                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
                 src:
                   type: oci
                   url: "{{ .Release.registry }}/pingcap/tidb-binlog/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -998,7 +998,7 @@ components:
                 src:
                   path: bin/reparo
               - name: arbiter
-                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
+                if: {{ semver.CheckConstraint "< 8.1.1-0 || >= 8.2.0-0" .Release.version }}
                 src:
                   path: bin/arbiter
               - name: binlogctl

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -998,6 +998,7 @@ components:
                 src:
                   path: bin/reparo
               - name: arbiter
+                if: {{ semver.CheckConstraint "< 8.1.1-0" .Release.version }}
                 src:
                   path: bin/arbiter
               - name: binlogctl


### PR DESCRIPTION
Starts from v8.1.1

Signed-off-by: wuhuizuo <wuhuizuo@126.com>