### PR TITLE
fix(packages): bump tiup-ctl version to v1.16.0 for `ctl` package

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -66,7 +66,7 @@ components:
               - name: ctl
                 src:
                   type: http
-                  url: "https://github.com/pingcap/tiup/releases/download/v1.8.1/tiup-v1.8.1-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  url: "https://github.com/pingcap/tiup/releases/download/v1.16.0/tiup-v1.16.0-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: bin/tiup-ctl
               - name: etcdctl


### PR DESCRIPTION
Starts from v8.4.0

Signed-off-by: wuhuizuo <wuhuizuo@126.com>