### PR TITLE
fix(packages/scripts): update to adjust new oras version

### DIFF
--- a/packages/scripts/build-package-artifacts.sh.tmpl
+++ b/packages/scripts/build-package-artifacts.sh.tmpl
@@ -256,7 +256,7 @@ function write_push_results() {
     # Login steps:
     #   local registry=$(echo "${destination}" | cut -d/ -f)
     #   oras login -u ${ORAS_USER} -p ${ORAS_PASSWD} ${registry}
-    digest="$(oras discover "${destination}" --distribution-spec v1.1-referrers-tag -o tree | cut -d@ -f2)"
+    digest="$(oras discover "${destination}" --distribution-spec v1.1-referrers-tag --format tree | cut -d@ -f2)"
 
     cat <<EOF > "$result_file"
 oci:

--- a/packages/scripts/compose-offline-packages-artifacts.sh.tmpl
+++ b/packages/scripts/compose-offline-packages-artifacts.sh.tmpl
@@ -280,7 +280,7 @@ function write_push_results() {
     # Login steps:
     #   local registry=$(echo "${destination}" | cut -d/ -f)
     #   oras login -u ${ORAS_USER} -p ${ORAS_PASSWD} ${registry}
-    digest="$(oras discover "${destination}" --distribution-spec v1.1-referrers-tag -o tree | cut -d@ -f2)"
+    digest="$(oras discover "${destination}" --distribution-spec v1.1-referrers-tag --format tree | cut -d@ -f2)"
 
     cat <<EOF > "$result_file"
 oci:


### PR DESCRIPTION
From oras v1.2.0, there's a break change for cli option of sub command `discover`. Ref: https://github.com/oras-project/oras/releases/tag/v1.2.0