### PR TITLE
fix(dockerfiles/ci/jenkins): set `USE_BAZEL_VERSION` env var to fixate the bazel version

### DIFF
--- a/dockerfiles/ci/jenkins/Dockerfile
+++ b/dockerfiles/ci/jenkins/Dockerfile
@@ -13,3 +13,9 @@ RUN groupadd -g 1000 jenkins && \
 # Switch to the non-root user jenkins and set the working directory
 USER jenkins
 WORKDIR /home/jenkins
+
+# TODO: we should set it in CI script or pipeline to avoid frequently update the image.
+ENV USE_BAZEL_VERSION=6.5.0
+
+# Other environment variables:
+# - `BAZELISK_BASE_URL` should be set in CI script or pipeline for different regions.


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>