### PR TITLE
chore: support build image for ci/jenkins dockerfile

### DIFF
--- a/.github/workflows/release-ci-runtime-images.yaml
+++ b/.github/workflows/release-ci-runtime-images.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - "dockerfiles/ci/base/**/Dockerfile"
       - "dockerfiles/ci/base/**/*.Dockerfile"
+      - "dockerfiles/ci/jenkins/**/Dockerfile"
+      - "dockerfiles/ci/jenkins/**/*.Dockerfile"
       - "dockerfiles/ci/skaffold.yaml"
 
 jobs:


### PR DESCRIPTION
support build image for ci/jenkins dockerfile