### PR TITLE
fix(pingcap/tiflash): fix builder image

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1621,7 +1621,7 @@ components:
         - {{ .Release.version }}
     builders:
       - if: {{ semver.CheckConstraint ">= 8.4.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2024.10.8-14-g52a7228
+        image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2024.11.7
       - if: {{ semver.CheckConstraint ">= 8.2.0-0, < 8.4.0-0" .Release.version }}
         image: hub.pingcap.net/ee/ci/release-build-base-tiflash:v20240625-llvm-17.0.6
       - if: {{ semver.CheckConstraint ">= 6.1.0-0, < 8.2.0-0" .Release.version }}


### PR DESCRIPTION
With the new version of tiflash builder to improve the performance of the artifacts.

Ref: https://github.com/pingcap/tiflash/pull/9587

Signed-off-by: wuhuizuo <wuhuizuo@126.com>