### PR TITLE
chore(tiflash): update build steps for tiflash starts v8.5.0

### DIFF
--- a/dockerfiles/cd/builders/tiflash/Dockerfile
+++ b/dockerfiles/cd/builders/tiflash/Dockerfile
@@ -84,8 +84,8 @@ ENV PATH /root/.cargo/bin/:$PATH
 FROM builder as building
 
 ADD . /ws
-RUN CARGO_NET_GIT_FETCH_WITH_CLI=true /ws/release-centos7-llvm/scripts/build-release.sh
-RUN mkdir output && mv /ws/release-centos7-llvm/tiflash output/tiflash
+RUN CARGO_NET_GIT_FETCH_WITH_CLI=true /ws/release-linux-llvm/scripts/build-release.sh
+RUN mkdir output && mv /ws/release-linux-llvm/tiflash output/tiflash
 RUN output/tiflash/tiflash version
 
 ########### stage: Final image

--- a/dockerfiles/cd/builders/tiflash/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tiflash/centos7/Dockerfile
@@ -16,7 +16,6 @@ LABEL org.opencontainers.image.authors "wuhui.zuo@pingcap.com"
 LABEL org.opencontainers.image.description "binary builder for tiflash"
 LABEL org.opencontainers.image.source = "https://github.com/PingCAP-QE/artifacts"
 
-# renovate: datasource=github-tags depName=pingcap/tiflash
 ARG TIFLASH_VER=v8.3.0
 RUN FILE=$([ "$(arch)" = "aarch64" ] && echo "bake_llvm_base_aarch64.sh" || echo "bake_llvm_base_amd64.sh"); \
     TAR_DIR="tiflash-$(echo $TIFLASH_VER | sed 's/v//')"; \

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1673,7 +1673,7 @@ components:
             files:
               - name: tiflash/
                 src:
-                  path: outputs/tiflash/    
+                  path: outputs/tiflash/
       - description: For v8.4.x
         if: {{ semver.CheckConstraint "~8.4.0-0" .Release.version }}
         os: [linux, darwin]

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1628,7 +1628,7 @@ components:
         image: hub.pingcap.net/ee/ci/release-build-base-tiflash:v20231106
     routers:
       - description: For range [v8.5.0, ) it changed the build script path.
-        if: {{ semver.CheckConstraint ">= 8.4.0-0" .Release.version }}
+        if: {{ semver.CheckConstraint ">= 8.5.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
         profile: [release, enterprise]

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1627,8 +1627,55 @@ components:
       - if: {{ semver.CheckConstraint ">= 6.1.0-0, < 8.2.0-0" .Release.version }}
         image: hub.pingcap.net/ee/ci/release-build-base-tiflash:v20231106
     routers:
-      - description: For range [v8.4.0, )
+      - description: For range [v8.5.0, ) it changed the build script path.
         if: {{ semver.CheckConstraint ">= 8.4.0-0" .Release.version }}
+        os: [linux, darwin]
+        arch: [amd64, arm64]
+        profile: [release, enterprise]
+        steps:
+          release:
+            - os: linux
+              script: |
+                ./release-rocky8-llvm/scripts/build-tiflash-release.sh
+                mkdir outputs
+                mv release-rocky8-llvm/tiflash outputs/tiflash
+            - os: darwin
+              script: |
+                ./release-darwin/build/build-release.sh
+                mkdir outputs
+                mv release-darwin/tiflash outputs/tiflash
+          enterprise:
+            - script: export TIFLASH_EDITION=Enterprise
+            - os: linux
+              script: |
+                ./release-rocky8-llvm/scripts/build-tiflash-release.sh
+                mkdir outputs
+                mv release-rocky8-llvm/tiflash outputs/tiflash
+            - os: darwin
+              script: |
+                ./release-darwin/build/build-release.sh
+                mkdir outputs
+                mv release-darwin/tiflash outputs/tiflash
+        artifacts:
+          - name: "tiflash-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files: # output files.
+              - name: tiflash/
+                src:
+                  path: outputs/tiflash/
+            tiup:
+              description: The TiFlash Columnar Storage Engine
+              entrypoint: tiflash/tiflash
+          - name: container image
+            type: image
+            artifactory:
+              repo: "{{ .Release.registry }}/pingcap/tiflash/image"
+            dockerfile: https://github.com/PingCAP-QE/artifacts/raw/main/dockerfiles/products/tiflash/Dockerfile
+            files:
+              - name: tiflash/
+                src:
+                  path: outputs/tiflash/    
+      - description: For v8.4.x
+        if: {{ semver.CheckConstraint "~8.4.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
         profile: [release, enterprise]

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1636,9 +1636,9 @@ components:
           release:
             - os: linux
               script: |
-                ./release-rocky8-llvm/scripts/build-tiflash-release.sh
+                ./release-linux-llvm/scripts/build-tiflash-release.sh
                 mkdir outputs
-                mv release-rocky8-llvm/tiflash outputs/tiflash
+                mv release-linux-llvm/tiflash outputs/tiflash
             - os: darwin
               script: |
                 ./release-darwin/build/build-release.sh
@@ -1648,9 +1648,9 @@ components:
             - script: export TIFLASH_EDITION=Enterprise
             - os: linux
               script: |
-                ./release-rocky8-llvm/scripts/build-tiflash-release.sh
+                ./release-linux-llvm/scripts/build-tiflash-release.sh
                 mkdir outputs
-                mv release-rocky8-llvm/tiflash outputs/tiflash
+                mv release-linux-llvm/tiflash outputs/tiflash
             - os: darwin
               script: |
                 ./release-darwin/build/build-release.sh


### PR DESCRIPTION
Ref https://github.com/pingcap/tiflash/pull/9587, it changes the build script paths.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>