### PR TITLE
build(tikv): bump tikv build image tag

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2170,7 +2170,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 8.4.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/tikv:v2024.10.8-51-g9b98efb-centos7
+        image: ghcr.io/pingcap-qe/cd/builders/tikv:v2024.10.8-63-gb22476a-centos7
       - if: {{ semver.CheckConstraint ">= 6.1.0-0, < 8.4.0-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/tikv:v20240325-24-gd14aee6
       - if: {{ and (semver.CheckConstraint "~6.5.6-0" .Release.version) (eq "fips" .Release.profile) }}


### PR DESCRIPTION
The new tag image is built with `dwz` tool installed.