### PR TITLE
feat(pingcap/ticdc): support publish artifacts for the repo's trunk branch

### DIFF
--- a/.github/scripts/ci.sh
+++ b/.github/scripts/ci.sh
@@ -36,6 +36,20 @@ function test_get_builder() {
         done
     done
 
+    # for cdc - only community edition
+    local cm="ticdc"
+    local versions="v9.0.0"
+    for version in $versions; do
+        for os in $operating_systems; do
+            for ac in $architectures; do
+                echo -en "[🚢] $cm $os $ac $version release:\t"
+                img=$($script "$cm" "$os" "$ac" "$version" release)
+                echo $img
+                check_image_existed $img
+            done
+        done
+    done
+
     # enterprise profile
     local components="tidb tiflash tikv pd"
     for cm in $components; do
@@ -119,6 +133,19 @@ function test_gen_package_artifacts_script() {
                     $script "$cm" "$os" "$ac" "$version" $profile branch-xxx 123456789abcdef
                     shellcheck -S error packages/scripts/build-package-artifacts.sh
                 done
+            done
+        done
+    done
+
+    # for cdc - only community edition
+    local cm="ticdc"
+    local versions="v9.0.0"
+    for version in $versions; do
+        for os in $operating_systems; do
+            for ac in $architectures; do
+                echo -en "[📃📦] $cm $os $ac $version $profile:\t"
+                $script "$cm" "$os" "$ac" "$version" $profile branch-xxx 123456789abcdef
+                shellcheck -S error packages/scripts/build-package-artifacts.sh
             done
         done
     done
@@ -222,6 +249,17 @@ function test_gen_package_images_script() {
                 $script "$cm" linux "$ac" "$version" "$profile" branch-xxx 123456789abcdef
                 shellcheck -S error packages/scripts/build-package-images.sh
             done
+        done
+    done
+
+    # for cdc - only community edition
+    local cm="ticdc"
+    local versions="v9.0.0"
+    for version in $versions; do
+        for ac in $architectures; do
+            echo -en "[📃💿] $cm $os $ac $version $profile:\t"
+            $script "$cm" linux "$ac" "$version" "$profile" branch-xxx 123456789abcdef
+            shellcheck -S error packages/scripts/build-package-images.sh
         done
     done
 

--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -47,6 +47,11 @@ image_copy_rules:
       dest_repositories:
         - docker.io/pingcap/advanced-statefulset
         - gcr.io/pingcap-public/dbaas/advanced-statefulset
+  hub.pingcap.net/pingcap/ticdc/image:
+    # only delivey the master branch images.
+    - <<: *sync_trunk_community
+      dest_repositories:
+        - docker.io/pingcap/ticdc
   hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator:
     - description: delivery the version images.
       tags_regex:
@@ -155,9 +160,10 @@ image_copy_rules:
         - gcr.io/pingcap-public/dbaas/dumpling
         - docker.io/pingcap/dumpling-enterprise
   hub.pingcap.net/pingcap/tiflow/images/cdc:
-    - <<: *sync_trunk_community
-      dest_repositories:
-        - docker.io/pingcap/ticdc
+    # We switch the `master` tag image building from `pingcap/tiflow` to `pingcap/ticdc` repo.
+    # - <<: *sync_trunk_community
+    #   dest_repositories:
+    #     - docker.io/pingcap/ticdc
     - <<: *sync_rc_community
       dest_repositories:
         - hub.pingcap.net/qa/ticdc

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1817,7 +1817,7 @@ components:
                 src:
                   path: outputs/tiflash/
   tiflow:
-    desc: tiflow components tarball
+    desc: tiflow components
     git:
       url: https://github.com/pingcap/tiflow.git
       ref: {{ .Git.ref | default "master" }}
@@ -2119,7 +2119,51 @@ components:
             dockerfile: deployments/engine/docker/Dockerfile
             build_args:
               - GOPROXY=http://goproxy.pingcap.net,https://goproxy.cn,direct
-
+  ticdc:
+    desc: ticdc components
+    git:
+      url: https://github.com/pingcap/ticdc.git
+      ref: {{ .Git.ref | default "master" }}
+      sha: {{ .Git.sha | default "" }}
+    version: {{ .Release.version }} # segment version.
+    artifactory:
+      package_repo: "{{ .Release.registry }}/pingcap/ticdc/package"
+      tags:
+        {{- if .Git.sha }}
+        - {{ strings.ReplaceAll "/" "-" .Git.ref | strings.ToLower }}-{{ strings.Trunc 7 .Git.sha }}
+        {{- end }}
+        - {{ strings.ReplaceAll "/" "-" .Git.ref | strings.ToLower }}
+        - {{ .Release.version }}
+    # binary builder, also we need it when build for mac to get build tools versions and other informations.
+    builders:
+      - if: {{ semver.CheckConstraint ">= 9.0.0-0" .Release.version }}
+        image: ghcr.io/pingcap-qe/cd/builders/ticdc:v2024.10.8-64-g95f12b0-centos7-go1.23
+    routers:
+      - description: For range [v9.0.0, )
+        if: {{ semver.CheckConstraint ">= 9.0.0-0" .Release.version }}
+        os: [linux, darwin]
+        arch: [amd64, arm64]
+        profile: [release]
+        steps:
+          release:
+            - script: make cdc
+        artifacts:
+          - name: "cdc-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files:
+              - name: cdc
+                src:
+                  path: bin/cdc
+            tiup:
+              description: >-
+                CDC is a change data capture tool for TiDB
+              entrypoint: cdc
+          - name: container image - cdc
+            type: image
+            artifactory:
+              repo: "{{ .Release.registry }}/pingcap/ticdc/image"
+            dockerfile: https://github.com/PingCAP-QE/artifacts/raw/main/dockerfiles/products/ticdc/Dockerfile
+            files: # context files
+              - { name: cdc, src: { path: bin/cdc } }
   tiflow-operator:
     desc: tiflow operator components tarball
     git:


### PR DESCRIPTION
Artifacts:

- tiup package `cdc` nightly version will be published to tiup mirror from this repo(switched from tiflow repo).
- container image `pingcap/ticdc:master` in docker hub will be published from this repo.