### PR TITLE
refactor(pingcap/tiflow,pingcap/tidb-tools): refactor the building of sync-diff-inspector tool

### DIFF
--- a/.github/scripts/ci.sh
+++ b/.github/scripts/ci.sh
@@ -25,6 +25,11 @@ function test_get_builder() {
     local components="tidb tiflow tiflash tikv pd ctl monitoring ng-monitoring tidb-tools"
     for cm in $components; do
         for version in $versions; do
+            # Skip tidb-tools for version v9.0.0
+            if [[ $cm == "tidb-tools" && $version == "v9.0.0" ]]; then
+                echo "Skipping tidb-tools for version v9.0.0"
+                continue
+            fi
             for os in $operating_systems; do
                 for ac in $architectures; do
                     echo -en "[🚢] $cm $os $ac $version release:\t"
@@ -127,6 +132,11 @@ function test_gen_package_artifacts_script() {
     local components="tidb tiflow tiflash tikv pd ctl monitoring ng-monitoring tidb-tools"
     for cm in $components; do
         for version in $versions; do
+            # Skip tidb-tools for version v9.0.0
+            if [[ $cm == "tidb-tools" && $version == "v9.0.0" ]]; then
+                echo "Skipping tidb-tools for version v9.0.0"
+                continue
+            fi
             for os in $operating_systems; do
                 for ac in $architectures; do
                     echo -en "[📃📦] $cm $os $ac $version $profile:\t"
@@ -244,6 +254,11 @@ function test_gen_package_images_script() {
     local components="tidb tiflow tiflash tikv pd ctl monitoring ng-monitoring tidb-tools"
     for cm in $components; do
         for version in $versions; do
+            # Skip tidb-tools for version v9.0.0
+            if [[ $cm == "tidb-tools" && $version == "v9.0.0" ]]; then
+                echo "Skipping tidb-tools for version v9.0.0"
+                continue
+            fi
             for ac in $architectures; do
                 echo -en "[📃💿] $cm $os $ac $version $profile:\t"
                 $script "$cm" linux "$ac" "$version" "$profile" branch-xxx 123456789abcdef

--- a/dockerfiles/products/tiflow/sync-diff-inspector.Dockerfile
+++ b/dockerfiles/products/tiflow/sync-diff-inspector.Dockerfile
@@ -1,0 +1,3 @@
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.9.2
+FROM $BASE_IMG
+COPY sync_diff_inspector /sync_diff_inspector

--- a/packages/README.md
+++ b/packages/README.md
@@ -7,7 +7,6 @@ Central declarative congfigurations for artifacts delivering.
 ## Prerequire tools
 
 - [gomplate](https://github.com/hairyhenderson/gomplate)
-  > Please install the master version.
 - [yq](https://github.com/mikefarah/yq)
 - [jq](https://jqlang.github.io/jq/download/)
 

--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=../schemas/delivery-schema.json
 deprecated:
-  - hub.pingcap.net/pingcap/tidb-binlog/image # deprecated in v8.3 and removed in v8.4.
+  # deprecated in v8.3 and removed in v8.4.
+  - hub.pingcap.net/pingcap/tidb-binlog/image
+  # deprecated and removed in v9.0.0, use hub.pingcap.net/pingcap/tiflow/images/sync-diff-inspector instead.
+  - hub.pingcap.net/pingcap/tidb-tools/image
 definitions:
   sync_trunk_community: &sync_trunk_community
     description: delivery the trunk branch images.
@@ -220,6 +223,13 @@ image_copy_rules:
     - <<: *sync_ga_community
       dest_repositories:
         - gcr.io/pingcap-public/tidbcloud/tiflow
+  hub.pingcap.net/pingcap/tiflow/images/sync-diff-inspector:
+    - <<: *sync_trunk_community
+      dest_repositories:
+        - docker.io/pingcap/sync-diff-inspector
+    - <<: *sync_ga_community
+      dest_repositories:
+        - docker.io/pingcap/sync-diff-inspector
   hub.pingcap.net/pingcap/tiflash/image:
     - <<: *sync_trunk_community
       dest_repositories:
@@ -290,10 +300,6 @@ image_copy_rules:
         - hub.pingcap.net/qa/ng-monitoring-enterprise
         - gcr.io/pingcap-public/dbaas/ng-monitoring
         - docker.io/pingcap/ng-monitoring-enterprise
-  hub.pingcap.net/pingcap/tidb-tools/image:
-    - <<: *sync_trunk_community
-      dest_repositories:
-        - docker.io/pingcap/tidb-tools
   hub.pingcap.net/pingcap/tidb-binlog/image:
     - <<: *sync_trunk_community
       dest_repositories:

--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -53,7 +53,76 @@ editions:
         - "{{ .Release.version }}-community"
     routers:
       - description: "Started from v8.4.0"
-        if: {{ semver.CheckConstraint ">=8.4.0-0" .Release.version }}
+        if: {{ semver.CheckConstraint ">=9.0.0-0" .Release.version }}
+        os: [linux]
+        arch: [amd64, arm64]
+        profile: [community]
+        artifacts:
+          - name: "tidb-community-server-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}"
+            desc: community offline server package
+            components:
+              - { name: tidb-dashboard, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: alertmanager, src: { type: tiup-clone, version: latest } }
+              - { name: blackbox_exporter, src: { type: tiup-clone, version: latest } }
+              - { name: node_exporter, src: { type: tiup-clone, version: latest } }
+              - { name: tiup, src: { type: tiup-clone, version: latest } }
+              - { name: cluster, src: { type: tiup-clone, version: latest } }
+              - { name: insight, src: { type: tiup-clone, version: latest } }
+              - { name: diag, src: { type: tiup-clone, version: latest } }
+              - { name: influxdb, src: { type: tiup-clone, version: latest } }
+              - { name: playground, src: { type: tiup-clone, version: latest } }
+              - { name: tiproxy, src: { type: tiup-clone, version: latest } }
+              - { name: tidb, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: tikv, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: pd, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: tiflash, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: ctl, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: prometheus, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: grafana, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+          - name: "tidb-community-toolkit-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}"
+            desc: community offline toolkit package
+            components:
+              - { name: tiup, src: { type: tiup-clone, version: latest } }
+              - { name: alertmanager, src: { type: tiup-clone, version: latest } } # New in v6.2.0
+              - { name: blackbox_exporter, src: { type: tiup-clone, version: latest } } # New in v6.2.0
+              - { name: node_exporter, src: { type: tiup-clone, version: latest } } # New in v6.2.0
+              - name: package
+                if: {{ eq .Release.arch "amd64" }}
+                src: { type: tiup-clone, version: latest }
+              - { name: bench, src: { type: tiup-clone, version: latest } }
+              - { name: errdoc, src: { type: tiup-clone, version: latest } }
+              - { name: dba, src: { type: tiup-clone, version: latest } }
+              - { name: PCC, src: { type: tiup-clone, version: latest } }
+              - { name: dm, src: { type: tiup-clone, version: latest } } # it's tiup-dm pkg not dm.
+              - { name: server, src: { type: tiup-clone, version: latest } } # New in v6.2.0, it's tiup-server.
+              - { name: pd-recover, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: tidb-lightning, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: dumpling, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: br, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: cdc, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: dm-master, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: dm-worker, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: dmctl, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: prometheus, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: grafana, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - name: tidb-lightning-ctl # New in v6.0.0
+                src:
+                  type: oci
+                  url: "{{ .Release.registry }}/pingcap/tidb/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"
+                  path: "tidb-lightning-ctl-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  extract: true
+                  extract_inner_path: tidb-lightning-ctl
+              - name: sync-diff-inspector # from raw binary to tiup pkg from v9.0.0
+                src: { type: tiup-clone, version: "{{ .Release.version }}" }
+              - name: etcdctl
+                src:
+                  type: http
+                  url: "https://github.com/etcd-io/etcd/releases/download/v3.5.15/etcd-v3.5.15-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  extract: true
+                  extract_inner_path: "etcd-v3.5.15-{{ .Release.os }}-{{ .Release.arch }}/etcdctl"
+
+      - description: "Started from v8.4.0 until v9.0.0"
+        if: {{ semver.CheckConstraint ">=8.4.0-0, < v9.0.0-0" .Release.version }}
         os: [linux]
         arch: [amd64, arm64]
         profile: [community]
@@ -115,8 +184,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # version release on master branch.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{ .Release.os }}_{{ .Release.arch }}"
+                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
+                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -214,8 +283,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # version release on master branch.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{ .Release.os }}_{{ .Release.arch }}"
+                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
+                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -312,8 +381,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # version release on master branch.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{ .Release.os }}_{{ .Release.arch }}"
+                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
+                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -412,8 +481,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # version release on master branch.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{ .Release.os }}_{{ .Release.arch }}"
+                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
+                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -518,8 +587,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # version release on master branch.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{ .Release.os }}_{{ .Release.arch }}"
+                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
+                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -542,8 +611,111 @@ editions:
       tags:
         - "{{ .Release.version }}-enterprise"
     routers:
-      - description: "Started from v8.4.0"
-        if: {{ semver.CheckConstraint ">=8.4.0-0" .Release.version }}
+      - description: "Started from v9.0.0"
+        if: {{ semver.CheckConstraint ">=9.0.0-0" .Release.version }}
+        os: [linux]
+        arch: [amd64, arm64]
+        artifacts:
+          - name: "tidb-enterprise-server-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}"
+            desc: enterprise offline server package
+            components:
+              - { name: tidb-dashboard, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: alertmanager, src: { type: tiup-clone, version: latest } }
+              - { name: blackbox_exporter, src: { type: tiup-clone, version: latest } }
+              - { name: node_exporter, src: { type: tiup-clone, version: latest } }
+              - { name: tiup, src: { type: tiup-clone, version: latest } }
+              - { name: cluster, src: { type: tiup-clone, version: latest } }
+              - { name: insight, src: { type: tiup-clone, version: latest } }
+              - { name: diag, src: { type: tiup-clone, version: latest } }
+              - { name: influxdb, src: { type: tiup-clone, version: latest } }
+              - { name: playground, src: { type: tiup-clone, version: latest } }
+              - { name: tiproxy, src: { type: tiup-clone, version: latest } }
+              - name: tidb
+                src:
+                  type: oci
+                  url: "{{ .Release.registry }}/pingcap/tidb/package:{{ .Release.version }}-enterprise_{{ .Release.os }}_{{ .Release.arch }}"
+                  path: "tidb-(v.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                publish:
+                  name: tidb
+                  description: >-
+                    TiDB is an open source distributed HTAP database compatible with the MySQL protocol.
+                  entrypoint: tidb-server
+              - name: tikv
+                src:
+                  type: oci
+                  url: "{{ .Release.registry }}/tikv/tikv/package:{{ .Release.version }}-enterprise_{{ .Release.os }}_{{ .Release.arch }}"
+                  path: "tikv-(v.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                publish:
+                  name: tikv
+                  description: >-
+                    Distributed transactional key-value database, originally created to complement TiDB.
+                  entrypoint: tikv-server
+              - name: pd
+                src:
+                  type: oci
+                  url: "{{ .Release.registry }}/tikv/pd/package:{{ .Release.version }}-enterprise_{{ .Release.os }}_{{ .Release.arch }}"
+                  path: "pd-(v.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                publish:
+                  name: pd
+                  description: >-
+                    PD is the abbreviation for Placement Driver. It is used to manage and schedule the TiKV cluster.
+                  entrypoint: pd-server
+              - name: tiflash
+                src:
+                  type: oci
+                  url: "{{ .Release.registry }}/pingcap/tiflash/package:{{ .Release.version }}-enterprise_{{ .Release.os }}_{{ .Release.arch }}"
+                  path: "tiflash-(v.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                publish:
+                  name: tiflash
+                  description: >-
+                    The TiFlash Columnar Storage Engine.
+                  entrypoint: tiflash/tiflash
+              - { name: ctl, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: prometheus, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: grafana, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+          - name: "tidb-enterprise-toolkit-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}"
+            desc: enterprise offline toolkit package
+            components:
+              - { name: tiup, src: { type: tiup-clone, version: latest } }
+              - { name: alertmanager, src: { type: tiup-clone, version: latest } } # New in v6.2.0
+              - { name: blackbox_exporter, src: { type: tiup-clone, version: latest } } # New in v6.2.0
+              - { name: node_exporter, src: { type: tiup-clone, version: latest } } # New in v6.2.0
+              - name: package
+                if: {{ eq .Release.arch "amd64" }}
+                src: { type: tiup-clone, version: latest }
+              - { name: bench, src: { type: tiup-clone, version: latest } }
+              - { name: errdoc, src: { type: tiup-clone, version: latest } }
+              - { name: dba, src: { type: tiup-clone, version: latest } }
+              - { name: PCC, src: { type: tiup-clone, version: latest } }
+              - { name: dm, src: { type: tiup-clone, version: latest } } # it's tiup-dm pkg not dm.
+              - { name: server, src: { type: tiup-clone, version: latest } } # New in v6.2.0, it's tiup-server.
+              - { name: pd-recover, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: tidb-lightning, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: dumpling, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: br, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: cdc, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: dm-master, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: dm-worker, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: dmctl, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: prometheus, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - { name: grafana, src: { type: tiup-clone, version: "{{ .Release.version }}" } }
+              - name: tidb-lightning-ctl # New in v6.0.0
+                src:
+                  type: oci
+                  url: "{{ .Release.registry }}/pingcap/tidb/package:{{ .Release.version }}_{{ .Release.os }}_{{ .Release.arch }}"
+                  path: "tidb-lightning-ctl-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  extract: true
+                  extract_inner_path: tidb-lightning-ctl
+              - name: sync-diff-inspector # from raw binary to tiup pkg from v9.0.0
+                src: { type: tiup-clone, version: "{{ .Release.version }}" }
+              - name: etcdctl	# New in v6.0.0
+                src:
+                  type: http
+                  url: "https://github.com/etcd-io/etcd/releases/download/v3.5.15/etcd-v3.5.15-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  extract: true
+                  extract_inner_path: "etcd-v3.5.15-{{ .Release.os }}-{{ .Release.arch }}/etcdctl"
+      - description: "Started from v8.4.0 until v9.0.0"
+        if: {{ semver.CheckConstraint ">=8.4.0-0, <9.0.0-0" .Release.version }}
         os: [linux]
         arch: [amd64, arm64]
         artifacts:
@@ -640,8 +812,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # version release on master branch.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{ .Release.os }}_{{ .Release.arch }}"
+                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
+                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -774,8 +946,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # version release on master branch.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{ .Release.os }}_{{ .Release.arch }}"
+                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
+                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -908,8 +1080,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # version release on master branch.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{ .Release.os }}_{{ .Release.arch }}"
+                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
+                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -1044,8 +1216,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # version release on master branch.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{ .Release.os }}_{{ .Release.arch }}"
+                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
+                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -1186,8 +1358,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # version release on master branch.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{ .Release.os }}_{{ .Release.arch }}"
+                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
+                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector

--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -185,7 +185,7 @@ editions:
                 src:
                   type: oci
                   # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -284,7 +284,7 @@ editions:
                 src:
                   type: oci
                   # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -382,7 +382,7 @@ editions:
                 src:
                   type: oci
                   # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -482,7 +482,7 @@ editions:
                 src:
                   type: oci
                   # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -588,7 +588,7 @@ editions:
                 src:
                   type: oci
                   # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -813,7 +813,7 @@ editions:
                 src:
                   type: oci
                   # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -947,7 +947,7 @@ editions:
                 src:
                   type: oci
                   # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -1081,7 +1081,7 @@ editions:
                 src:
                   type: oci
                   # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -1217,7 +1217,7 @@ editions:
                 src:
                   type: oci
                   # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -1359,7 +1359,7 @@ editions:
                 src:
                   type: oci
                   # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2016,7 +2016,7 @@ components:
                   path: bin/sync_diff_inspector
             tiup:
               description: >-
-                A tool to verify data consistency between MySQL-compatible databases.
+                sync-diff-inspector is a tool used to verify the consistency across different MySQL-compatible data sources.
               entrypoint: sync_diff_inspector
           - name: container image - sync-diff-inspector
             type: image

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1272,8 +1272,9 @@ components:
       - if: {{ ne "experiment" .Release.profile }}
         image: ghcr.io/pingcap-qe/cd/builders/tidb:v2024.10.8-12-gb9ffe36-centos7-go1.21
     routers:
-      - description: interpret versions according to semantic version spec.
-        if: {{ semver.CheckConstraint ">= 6.1.0-0" .Release.version }}
+      - description: >
+            for range [6.1.0, v9.0.0), it stop at v8.5.1. sync diff inspector tool is migrate to pingcap/tiflow repo.
+        if: {{ semver.CheckConstraint ">= 6.1.0-0, < v9.0.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
         profile: [release, experiment]
@@ -1952,7 +1953,7 @@ components:
                 node --version && npm --version
                 npm install -g yarn
             - script: |
-                make dm-master-with-webui dm-worker dmctl dm-syncer
+                make dm-master-with-webui dm-worker dmctl dm-syncer sync-diff-inspector
         artifacts:
           - name: "dm-master-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
             files:
@@ -2008,6 +2009,24 @@ components:
               description: >-
                 dmctl component of Data Migration Platform.
               entrypoint: dmctl/dmctl
+          - name: "sync-diff-inspector-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files:
+              - name: sync_diff_inspector
+                src:
+                  path: bin/sync_diff_inspector
+            tiup:
+              description: >-
+                A tool to verify data consistency between MySQL-compatible databases.
+              entrypoint: sync_diff_inspector
+          - name: container image - sync-diff-inspector
+            type: image
+            artifactory:
+              repo: "{{ .Release.registry }}/pingcap/tiflow/images/sync-diff-inspector"
+            dockerfile: https://github.com/PingCAP-QE/artifacts/raw/main/dockerfiles/products/tiflow/{{ template "image_dockerfile_folder" .Release.version }}sync-diff-inspector.Dockerfile
+            files:
+              - name: sync_diff_inspector
+                src:
+                  path: bin/sync_diff_inspector
           - name: container image - dm
             type: image
             artifactory:


### PR DESCRIPTION
## Changes

- migrate building from `pingcap/tidb-tools` to `pingcap/tiflow` repo.
- publish tiup package: `sync-diff-inspector`.
- build and deliver image to `docker.io/pingcap/sync-diff-inspector`.
- compose offline toolkit package with tiup package `sync-diff-inspector` rather than `sync_diff_inspector` raw binary file.

Close #546