### PR TITLE
fix(tiflash): add failpoint build target

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1876,7 +1876,6 @@ components:
                 mkdir outputs
                 mv release-centos7-llvm/tiflash outputs/tiflash
           failpoint:
-            - script: export TIFLASH_EDITION=Enterprise
             - os: linux
               script: |
                 # Create new build script to take advantage of ccache


### PR DESCRIPTION
Close #554

This pull request includes several changes to the `packages/packages.yaml.tmpl` file to update build scripts and add a new build profile. The most important changes include modifying the build scripts for various operating systems and architectures, and introducing a new `failpoint` profile for debugging purposes.

Updates to build scripts:

* Changed the build script from `build-tiflash-release.sh` to `build-release.sh` for Linux and Darwin operating systems. [[1]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1714-R1719) [[2]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1731-R1739) [[3]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1766-R1767) [[4]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1778-R1787)
* Updated the build script for CentOS 7 to use `build-release.sh` instead of `build-tiflash-release.sh`. [[1]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1766-R1767) [[2]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1778-R1787)

Introduction of `failpoint` profile:

* Added a `failpoint` profile with a build script `build-debug.sh` for Linux. [[1]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1731-R1739) [[2]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1778-R1787) [[3]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1848-R1879) [[4]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1874-R1899)

Enhancements for enterprise builds:

* Modified enterprise builds to utilize ccache for improved build performance and consistency.