### PR TITLE
fix(tiflash): fix failpoint profile for history release branches

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1759,7 +1759,7 @@ components:
         if: {{ semver.CheckConstraint "~8.4.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
-        profile: [release, enterprise]
+        profile: [release, enterprise, failpoint]
         steps:
           release:
             - os: linux
@@ -1807,7 +1807,7 @@ components:
         if: {{ semver.CheckConstraint ">= 6.1.0-0, < 8.4.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
-        profile: [release, enterprise]
+        profile: [release, enterprise, failpoint]
         steps:
           release:
             - os: darwin


### PR DESCRIPTION
This pull request includes changes to the `packages/packages.yaml.tmpl` file to add a new profile option for the build steps.

Changes to build profiles:

* [`packages/packages.yaml.tmpl`](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1762-R1762): Added `failpoint` to the `profile` list for versions `~8.4.0-0` and `>= 6.1.0-0, < 8.4.0-0`. [[1]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1762-R1762) [[2]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1810-R1810)