### PR TITLE
Configure backup-manager image for operator-v2

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1469,6 +1469,13 @@ components:
             context: .
             dockerfile: image/Dockerfile
             target: prestop-checker # target build stage in Dockerfile
+          - name: container image - backup-manager
+            type: image
+            artifactory:
+              repo: "{{ .Release.registry }}/pingcap/tidb-operator/images/backup-manager"
+            context: .
+            dockerfile: image/Dockerfile
+            target: backup-manager # target build stage in Dockerfile
       - description: for range [v1.5.0, v2.0.0)
         if: {{ semver.CheckConstraint ">= 1.5.0-0, < 2.0.0-0" .Release.version }}
         os: [linux]


### PR DESCRIPTION
This pull request includes a new container image definition in the `packages/packages.yaml.tmpl` file. The change adds a new image for the `backup-manager` component, specifying its type, artifactory repository, context, Dockerfile, and target build stage.

Changes in `components`:

* Added a new container image definition for `backup-manager` with details on its type, artifactory repository, context, Dockerfile, and target build stage.