### PR TITLE
fix(tidb-operator): fix repo of `tidb-backup-manager`

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1472,7 +1472,7 @@ components:
           - name: container image - backup-manager
             type: image
             artifactory:
-              repo: "{{ .Release.registry }}/pingcap/tidb-operator/images/backup-manager"
+              repo: "{{ .Release.registry }}/pingcap/tidb-operator/images/tidb-backup-manager"
             context: .
             dockerfile: image/Dockerfile
             target: backup-manager # target build stage in Dockerfile


### PR DESCRIPTION
This pull request includes a change to the `packages/packages.yaml.tmpl` file to update the repository name for the `backup-manager` container image. The change ensures that the repository name is consistent with other images in the project.

Repository name update:

* [`packages/packages.yaml.tmpl`](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1475-R1475): Changed the repository name for the `backup-manager` container image from `backup-manager` to `tidb-backup-manager`.