### PR TITLE
revert(packages): revert the changes on offline packages about sync_diff_inspector tool for history versions

### DIFF
--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -184,8 +184,7 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -283,8 +282,7 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -381,8 +379,7 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -481,8 +478,7 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -587,8 +583,7 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -812,8 +807,7 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -946,8 +940,7 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -1080,8 +1073,7 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -1216,8 +1208,7 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
@@ -1358,8 +1349,7 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  # sync_diff_inspector stop builds after v8.5.1 on tidb-tools repo. So we use the latest v8.5.x version for patch version lower then v9.0.0.
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:v8.5.1_{{.Release.os }}_{{ .Release.arch }}"
+                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
                   path: "tidb-tools-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector


### PR DESCRIPTION
for v8.5.x and lower versions, we still release with the latest code from master branch.