### PR TITLE
feat(dockerfiles/cd/builders/tikv): add perl cpans in centos7 builder

### DIFF
--- a/dockerfiles/cd/builders/tikv/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tikv/centos7/Dockerfile
@@ -20,7 +20,7 @@ RUN yum install --nogpgcheck -y epel-release centos-release-scl deltarpm && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
     ([ "$(arch)" = "x86_64" ] || sed -i s#vault.centos.org/centos/7/sclo/#vault.centos.org/altarch/7/sclo/#g /etc/yum.repos.d/*.repo) && \
     yum update --nogpgcheck -y && \
-    yum install -y git devtoolset-${DEVTOOLSET_VER} perl cmake3 unzip dwz && \
+    yum install -y git devtoolset-${DEVTOOLSET_VER} perl cmake3 unzip dwz perl-IPC-Cmd perl-Data-Dumper && \
     yum clean all && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake
 ENV DEVTOOLSET_VER ${DEVTOOLSET_VER}


### PR DESCRIPTION
This pull request includes a minor update to the `dockerfiles/cd/builders/tikv/centos7/Dockerfile` to enhance the build environment by adding additional Perl modules.

Enhancements to build environment:

* [`dockerfiles/cd/builders/tikv/centos7/Dockerfile`](diffhunk://#diff-bceb5c0ebca4756e35995a954151c6bbf2b8f74ff379c76fb99be4d26ad87875L23-R23): Added `perl-IPC-Cmd` and `perl-Data-Dumper` to the list of packages installed to ensure necessary Perl modules are available.