### PR TITLE
fix: sync new ticdc image since v9.0.0-beta

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -66,6 +66,25 @@ image_copy_rules:
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/ticdc
+    - <<: *sync_rc_community
+      dest_repositories:
+        - hub.pingcap.net/qa/ticdc
+    # TODO: enable the GA delivery /cc @wuhuizuo
+    # - <<: *sync_ga_community
+    #   dest_repositories:
+    #     - hub.pingcap.net/qa/ticdc
+    #     - docker.io/pingcap/ticdc
+    #     - uhub.service.ucloud.cn/pingcap/ticdc
+    - <<: *sync_rc_community_to_enterprise_repo
+      dest_repositories:
+        - hub.pingcap.net/qa/ticdc-enterprise
+        - gcr.io/pingcap-public/dbaas/ticdc
+    # TODO: enable the GA delivery /cc @wuhuizuo
+    # - <<: *sync_ga_community_to_enterprise_repo
+    #   dest_repositories:
+    #     - hub.pingcap.net/qa/ticdc-enterprise
+    #     - gcr.io/pingcap-public/dbaas/ticdc
+    #     - docker.io/pingcap/ticdc-enterprise
   hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator:
     - description: delivery the v1 version images.
       tags_regex:


### PR DESCRIPTION
sync new ticdc image since v9.0.0-beta