### PR TITLE
feat(packages): update TiCI builder to use PingCAP's pre-configured image

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2788,7 +2788,7 @@ components:
         - {{ .Release.version }}
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
-      - image: docker.io/library/rust:1.85.0
+      - image: ghcr.io/pingcap-qe/cd/builders/tikv:v2024.10.8-139-g74d1fec-centos7-devtoolset10
     routers:
       - description: currently in demo stage
         os: [linux]
@@ -2801,9 +2801,6 @@ components:
                 echo "Rust version: $(rustc --version)"
                 echo "Cargo version: $(cargo --version)"
 
-                # install protoc tool
-                apt-get update && apt-get install -y protobuf-compiler
-            - script: |
                 cargo build --release
         artifacts:
           - name: "tici-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"


### PR DESCRIPTION
This pull request updates the Rust builder image used in the `packages.yaml.tmpl` file and removes an unnecessary installation step for the `protobuf-compiler` tool. These changes improve the build process by aligning with updated dependencies and simplifying the build script.

### Updates to builder configuration:

* Updated the Rust builder image from `docker.io/library/rust:1.85.0` to `ghcr.io/pingcap-qe/cd/builders/tikv:v2024.10.8-139-g74d1fec-centos7-devtoolset10`, ensuring compatibility with the latest build tools and dependencies.

### Simplification of build script:

* Removed the installation step for the `protobuf-compiler` tool (`apt-get update && apt-get install -y protobuf-compiler`), as it is no longer required in the build process.