### PR TITLE
chore(dockerfiles): fix expose port for tikv-ctl

### DIFF
--- a/dockerfiles/products/tikv/next-gen.Dockerfile
+++ b/dockerfiles/products/tikv/next-gen.Dockerfile
@@ -3,5 +3,6 @@ FROM $BASE_IMG
 COPY tikv-server /tikv-server
 COPY cse-ctl /cse-ctl
 COPY tikv-worker /tikv-worker
-EXPOSE 20160 20180
+ENV MALLOC_CONF="prof:true,prof_active:false"
+EXPOSE 20160
 ENTRYPOINT ["/tikv-server"]

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2831,6 +2831,7 @@ components:
         steps:
           release:
             - script: |
+                source /opt/rh/devtoolset-10/enable
                 # Verify Rust environment
                 echo "Rust version: $(rustc --version)"
                 echo "Cargo version: $(cargo --version)"

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2750,7 +2750,7 @@ components:
             type: image
             artifactory:
               repo: "{{ .Release.registry }}/tikv/tikv/image"
-            dockerfile: https://github.com/PingCAP-QE/artifacts/raw/main/dockerfiles/products/tikv/cse.Dockerfile
+            dockerfile: https://github.com/PingCAP-QE/artifacts/raw/main/dockerfiles/products/tikv/next-gen.Dockerfile
             files: # prepare for context
               - { name: tikv-server, src: { path: bin/tikv-server } }
               - { name: cse-ctl, src: { path: bin/cse-ctl } }


### PR DESCRIPTION
Historical debt introduced before 2021 Year: not updated and synchronized in time, but this has no impact on production/operation. 

Tip: 'expose' in `Dockerfile` is just a description.

**Do NOT add `EXPOSE 20180`** because:
   - The container's entrypoint is set to `/tikv-server`
   - `cse-ctl` won't be running automatically
   - Including an `EXPOSE` for a port that won't be listening could be misleading for other developers