### PR TITLE
feature(dockerfiles): set MALLOC_CONF environment variable in TiFlash image

### DIFF
--- a/dockerfiles/products/tiflash/Dockerfile
+++ b/dockerfiles/products/tiflash/Dockerfile
@@ -2,4 +2,5 @@ ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.9.2
 FROM $BASE_IMG
 ENV LD_LIBRARY_PATH /tiflash
 COPY tiflash /tiflash
+ENV MALLOC_CONF="prof:true,prof_active:false"
 ENTRYPOINT ["/tiflash/tiflash", "server"]

--- a/dockerfiles/products/tiflash/Dockerfile
+++ b/dockerfiles/products/tiflash/Dockerfile
@@ -2,5 +2,7 @@ ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.9.2
 FROM $BASE_IMG
 ENV LD_LIBRARY_PATH /tiflash
 COPY tiflash /tiflash
+# Enable jemalloc profiling, inactive by default.
+# See https://jemalloc.net/jemalloc.3.html for details.
 ENV MALLOC_CONF="prof:true,prof_active:false"
 ENTRYPOINT ["/tiflash/tiflash", "server"]


### PR DESCRIPTION
Enable profiling capability but incative default.

Ref pingcap/tiflash#9320