### PR TITLE
feat(workflows/ci): add change detection jobs for CI and release workflows

### DIFF
--- a/.github/workflows/pull-ci-runtime-images.yaml
+++ b/.github/workflows/pull-ci-runtime-images.yaml
@@ -16,9 +16,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    name: Detect file changes
+    runs-on: ubuntu-24.04
+    outputs:
+      base-jenkins: ${{ steps.filter.outputs.base-jenkins }}
+      jenkins-special: ${{ steps.filter.outputs.jenkins-special }}
+      tici: ${{ steps.filter.outputs.tici }}
+      skaffold: ${{ steps.filter.outputs.skaffold }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            base-jenkins:
+              - 'dockerfiles/ci/base/**/Dockerfile'
+              - 'dockerfiles/ci/base/**/*.Dockerfile'
+              - 'dockerfiles/ci/jenkins/Dockerfile'
+            jenkins-special:
+              - 'dockerfiles/ci/jenkins/tikv/**'
+              - 'dockerfiles/ci/jenkins/tiflash/**'
+            tici:
+              - 'dockerfiles/ci/tici/**'
+            skaffold:
+              - 'dockerfiles/ci/skaffold.yaml'
   skaffold-go:
     name: build go images with skaffold
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.base-jenkins == 'true' || needs.detect-changes.outputs.skaffold == 'true' }}
 
     permissions:
       contents: read
@@ -78,6 +106,8 @@ jobs:
   skaffold-jenkins-nogo:
     name: build jenkins nogo images with skaffold
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.jenkins-special == 'true' || needs.detect-changes.outputs.skaffold == 'true' }}
 
     permissions:
       contents: read
@@ -125,6 +155,8 @@ jobs:
   skaffold-common:
     name: build common images with skaffold
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.tici == 'true' || needs.detect-changes.outputs.skaffold == 'true' }}
 
     permissions:
       contents: read
@@ -132,7 +164,7 @@ jobs:
 
     strategy:
       matrix:
-        module: [ci]
+        module: [ci-tici]
         platform: [linux/amd64, linux/arm64]
     steps:
       - name: Checkout sources

--- a/.github/workflows/release-ci-runtime-images.yaml
+++ b/.github/workflows/release-ci-runtime-images.yaml
@@ -13,9 +13,43 @@ on:
       - "dockerfiles/ci/skaffold.yaml"
 
 jobs:
+  detect-changes:
+    name: Detect file changes
+    runs-on: ubuntu-24.04
+    # 只有在 push 事件时才检测变更，workflow_dispatch 时跳过检测（构建所有镜像）
+    if: github.event_name == 'push'
+    outputs:
+      base-jenkins: ${{ steps.filter.outputs.base-jenkins }}
+      jenkins-special: ${{ steps.filter.outputs.jenkins-special }}
+      tici: ${{ steps.filter.outputs.tici }}
+      skaffold: ${{ steps.filter.outputs.skaffold }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            base-jenkins:
+              - 'dockerfiles/ci/base/**/Dockerfile'
+              - 'dockerfiles/ci/base/**/*.Dockerfile'
+              - 'dockerfiles/ci/jenkins/Dockerfile'
+            jenkins-special:
+              - 'dockerfiles/ci/jenkins/tikv/**'
+              - 'dockerfiles/ci/jenkins/tiflash/**'
+            tici:
+              - 'dockerfiles/ci/tici/**'
+            skaffold:
+              - 'dockerfiles/ci/skaffold.yaml'
   skaffold-go:
     name: publish images with skaffold
     runs-on: ubuntu-24.04
+    needs: [detect-changes]
+    if: |
+      always() && 
+      (github.event_name == 'workflow_dispatch' || 
+       needs.detect-changes.outputs.base-jenkins == 'true' || 
+       needs.detect-changes.outputs.skaffold == 'true')
 
     permissions:
       contents: read
@@ -76,6 +110,12 @@ jobs:
   skaffold-jenkins-nogo:
     name: publish images with skaffold
     runs-on: ubuntu-24.04
+    needs: [detect-changes]
+    if: |
+      always() && 
+      (github.event_name == 'workflow_dispatch' || 
+       needs.detect-changes.outputs.jenkins-special == 'true' || 
+       needs.detect-changes.outputs.skaffold == 'true')
 
     permissions:
       contents: read
@@ -122,13 +162,19 @@ jobs:
   skaffold-common:
     name: publish images with skaffold
     runs-on: ubuntu-24.04
+    needs: [detect-changes]
+    if: |
+      always() && 
+      (github.event_name == 'workflow_dispatch' || 
+       needs.detect-changes.outputs.tici == 'true' || 
+       needs.detect-changes.outputs.skaffold == 'true')
 
     permissions:
       contents: read
       packages: write
     strategy:
       matrix:
-        module: [ci]
+        module: [ci-tici]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/release-ci-runtime-images.yaml
+++ b/.github/workflows/release-ci-runtime-images.yaml
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [detect-changes]
     if: |
-      always() && 
-      (github.event_name == 'workflow_dispatch' || 
-       needs.detect-changes.outputs.base-jenkins == 'true' || 
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+       needs.detect-changes.outputs.base-jenkins == 'true' ||
        needs.detect-changes.outputs.skaffold == 'true')
 
     permissions:
@@ -112,9 +112,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [detect-changes]
     if: |
-      always() && 
-      (github.event_name == 'workflow_dispatch' || 
-       needs.detect-changes.outputs.jenkins-special == 'true' || 
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+       needs.detect-changes.outputs.jenkins-special == 'true' ||
        needs.detect-changes.outputs.skaffold == 'true')
 
     permissions:
@@ -164,9 +164,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [detect-changes]
     if: |
-      always() && 
-      (github.event_name == 'workflow_dispatch' || 
-       needs.detect-changes.outputs.tici == 'true' || 
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+       needs.detect-changes.outputs.tici == 'true' ||
        needs.detect-changes.outputs.skaffold == 'true')
 
     permissions:

--- a/dockerfiles/ci/skaffold.yaml
+++ b/dockerfiles/ci/skaffold.yaml
@@ -17,13 +17,6 @@ build:
       requires:
         - image: base
           alias: BASE_IMG
-    - image: tici
-      platforms: [linux/amd64, linux/arm64]
-      docker:
-        dockerfile: tici/Dockerfile
-      requires:
-        - image: base
-          alias: BASE_IMG
   tagPolicy:
     customTemplate:
       template: "{{ .GIT }}"
@@ -74,6 +67,25 @@ build:
       platforms: [linux/amd64, linux/arm64]
       docker:
         dockerfile: jenkins/tikv/Dockerfile
+  tagPolicy:
+    customTemplate:
+      template: "{{ .GIT }}"
+  local:
+    useDockerCLI: true
+    useBuildkit: true
+    concurrency: 0
+    tryImportMissing: true
+---
+apiVersion: skaffold/v4beta6
+kind: Config
+metadata:
+  name: ci-tici
+build:
+  artifacts:
+    - image: tici
+      platforms: [linux/amd64, linux/arm64]
+      docker:
+        dockerfile: tici/Dockerfile
   tagPolicy:
     customTemplate:
       template: "{{ .GIT }}"


### PR DESCRIPTION
Introduced a new job to detect file changes in the CI and release workflows, allowing conditional execution of subsequent jobs based on the presence of changes in specific Dockerfiles and configuration files. Updated the skaffold configuration to reflect the new job structure and renamed the CI module to `ci-tici` for clarity.

- Added `detect-changes` job to both workflows.
- Updated job dependencies to conditionally run based on detected changes.
- Refactored skaffold configuration to include `ci-tici`.