### PR TITLE
chore(workflow): Update CI workflow to use arc-runner-set-pingcap-qe for image publishing

### DIFF
--- a/.github/workflows/release-ci-runtime-images.yaml
+++ b/.github/workflows/release-ci-runtime-images.yaml
@@ -161,7 +161,7 @@ jobs:
 
   skaffold-common:
     name: publish images with skaffold
-    runs-on: ubuntu-24.04
+    runs-on: arc-runner-set-pingcap-qe
     needs: [detect-changes]
     if: |
       always() &&


### PR DESCRIPTION
The default runner build will encounter an error.
```shell
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20250704-084430-utc.log'
```