### PR TITLE
fix(tici): update builder image for tici and remove devtoolset source step

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2913,7 +2913,7 @@ components:
         - {{ .Release.version }}
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
-      - image: ghcr.io/pingcap-qe/cd/builders/tikv:v2024.10.8-139-g74d1fec-centos7-devtoolset10
+      - image: ghcr.io/pingcap-qe/cd/builders/tici:v2025.7.6-4-g46d18e4-centos7
     routers:
       - description: currently in demo stage
         os: [linux]
@@ -2922,7 +2922,6 @@ components:
         steps:
           release:
             - script: |
-                source /opt/rh/devtoolset-10/enable
                 # Verify Rust environment
                 echo "Rust version: $(rustc --version)"
                 echo "Cargo version: $(cargo --version)"


### PR DESCRIPTION
Build it with new builder image with llvm-clang 17+.