### PR TITLE
fix(pingcap/tidb-operator): update image copy rules to support all version tags except pre-release

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -82,10 +82,9 @@ image_copy_rules:
         - gcr.io/pingcap-public/dbaas/ticdc
         - docker.io/pingcap/ticdc-enterprise
   hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator:
-    - description: delivery the v1 and v2 version images.
+    - description: delivery the version images.
       tags_regex:
-        - ^(v1[.][0-9]+[.][0-9]+)(-.+)?$
-        - ^(v2[.][0-9]+[.][0-9]+)(-.+)?$
+        - ^(v[0-9]+[.][0-9]+[.][0-9]+)(-(?!pre(\.|$)).*)?$
       dest_repositories:
         - docker.io/pingcap/tidb-operator
         - gcr.io/pingcap-public/dbaas/tidb-operator
@@ -94,10 +93,9 @@ image_copy_rules:
         - docker.io/pingcap/tidb-operator
         - gcr.io/pingcap-public/dbaas/tidb-operator
   hub.pingcap.net/pingcap/tidb-operator/images/tidb-backup-manager:
-    - description: delivery the v1 and v2 version images.
+    - description: delivery the version images.
       tags_regex:
-        - ^(v1[.][0-9]+[.][0-9]+)(-.+)?$
-        - ^(v2[.][0-9]+[.][0-9]+)(-.+)?$
+        - ^(v[0-9]+[.][0-9]+[.][0-9]+)(-(?!pre(\.|$)).*)?$
       dest_repositories:
         - docker.io/pingcap/tidb-backup-manager
         - gcr.io/pingcap-public/dbaas/tidb-backup-manager
@@ -106,9 +104,9 @@ image_copy_rules:
         - docker.io/pingcap/tidb-backup-manager
         - gcr.io/pingcap-public/dbaas/tidb-backup-manager
   hub.pingcap.net/pingcap/tidb-operator/images/prestop-checker:
-    - description: delivery the v2 version images, it is in development.
+    - description: delivery the v2 version images.
       tags_regex:
-        - ^(v2[.][0-9]+[.][0-9]+)(-.+)?$
+        - ^(v2[.][0-9]+[.][0-9]+)(-(?!pre(\.|$)).*)?$
       dest_repositories:
         - docker.io/pingcap/tidb-operator-prestop-checker
         - gcr.io/pingcap-public/dbaas/tidb-operator-prestop-checker


### PR DESCRIPTION
## Tested

### for GA version
```console
> ./packages/scripts/gen-delivery-image-commands.ts --image_url=hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator:v2.0.0
Matching rule found for image URL 'hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator:v2.0.0':
	Description: delivery the version images.
	Source Repository: hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator
	Destination Repository: docker.io/pingcap/tidb-operator
	Destination Repository: gcr.io/pingcap-public/dbaas/tidb-operator
```

### for Beta version
```console
> ./packages/scripts/gen-delivery-image-commands.ts --image_url=hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator:v2.0.0-beta.1
Matching rule found for image URL 'hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator:v2.0.0-beta.1':
	Description: delivery the version images.
	Source Repository: hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator
	Destination Repository: docker.io/pingcap/tidb-operator
	Destination Repository: gcr.io/pingcap-public/dbaas/tidb-operator
```

### for pre built version
```console
> ./packages/scripts/gen-delivery-image-commands.ts --image_url=hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator:v2.0.0-pre
🤷 No delivery rule matched.
> ./packages/scripts/gen-delivery-image-commands.ts --image_url=hub.pingcap.net/pingcap/tidb-operator/images/tidb-operator:v2.0.0-pre.1
🤷 No delivery rule matched.
```


