### PR TITLE
chore: update CI workflow to use ubuntu-24.04 for skaffold-common job

### DIFF
--- a/.github/workflows/release-ci-runtime-images.yaml
+++ b/.github/workflows/release-ci-runtime-images.yaml
@@ -161,7 +161,7 @@ jobs:
 
   skaffold-common:
     name: publish images with skaffold
-    runs-on: [self-hosted, ARM64]
+    runs-on: ubuntu-24.04
     needs: [detect-changes]
     if: |
       always() &&


### PR DESCRIPTION
update CI workflow to use ubuntu-24.04 for skaffold-common job