### PR TITLE
fix(packages): deliver trunk branch enterprise images to GCR.io for `pingcap/tidb` repo

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -6,10 +6,12 @@ deprecated:
   - hub.pingcap.net/pingcap/tidb-tools/image
 definitions:
   sync_trunk_community: &sync_trunk_community
-    description: delivery the trunk branch images.
+    description: delivery the trunk branch community images.
     tags_regex: [^master(-experiment)?$]
     constant_tags: [nightly] # add new tags.
-  sync_trunk_enterprise: &sync_trunk_enterprise {}
+  sync_trunk_enterprise: &sync_trunk_enterprise
+    description: delivery the trunk branch enterprise edition images.
+    tags_regex: [^master-enterprise$]
   sync_trunk_next-gen: &sync_trunk_next-gen
     description: delivery next-gen images for developing branches.
     tags_regex:
@@ -119,9 +121,11 @@ image_copy_rules:
     - <<: *sync_trunk_next-gen
       dest_repositories:
         - gcr.io/pingcap-public/dbaas/tidb
-    - <<: *sync_trunk_community
+    - <<: *sync_trunk_enterprise
       dest_repositories:
         - gcr.io/pingcap-public/dbaas/tidb
+    - <<: *sync_trunk_community
+      dest_repositories:
         - docker.io/pingcap/tidb
     - <<: *sync_pre_enterprise
       dest_repositories:
@@ -138,9 +142,11 @@ image_copy_rules:
     - <<: *sync_trunk_next-gen
       dest_repositories:
         - gcr.io/pingcap-public/dbaas/br
-    - <<: *sync_trunk_community
+    - <<: *sync_trunk_enterprise
       dest_repositories:
         - gcr.io/pingcap-public/dbaas/br
+    - <<: *sync_trunk_community
+      dest_repositories:
         - docker.io/pingcap/br
     - <<: *sync_ga_community
       dest_repositories:
@@ -157,9 +163,11 @@ image_copy_rules:
     - <<: *sync_trunk_next-gen
       dest_repositories:
         - gcr.io/pingcap-public/dbaas/tidb-lightning
-    - <<: *sync_trunk_community
+    - <<: *sync_trunk_enterprise
       dest_repositories:
         - gcr.io/pingcap-public/dbaas/tidb-lightning
+    - <<: *sync_trunk_community
+      dest_repositories:
         - docker.io/pingcap/tidb-lightning
     - <<: *sync_ga_community
       dest_repositories:
@@ -176,6 +184,9 @@ image_copy_rules:
     - <<: *sync_trunk_next-gen
       dest_repositories:
         - gcr.io/pingcap-public/dbaas/dumpling
+    - <<: *sync_trunk_enterprise
+      dest_repositories:
+        - docker.io/pingcap/dumpling
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/dumpling

--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -186,7 +186,7 @@ image_copy_rules:
         - gcr.io/pingcap-public/dbaas/dumpling
     - <<: *sync_trunk_enterprise
       dest_repositories:
-        - docker.io/pingcap/dumpling
+        - gcr.io/pingcap-public/dbaas/dumpling
     - <<: *sync_trunk_community
       dest_repositories:
         - docker.io/pingcap/dumpling


### PR DESCRIPTION
This pull request updates the image delivery configuration in `packages/delivery.yaml` to better distinguish between community and enterprise edition images for several products. The main changes involve adding explicit rules and descriptions for syncing enterprise edition images, ensuring they are delivered to the appropriate repositories, and clarifying the handling of community edition images.

**Image sync rules and configuration:**

* Added a detailed description and tag pattern for the `sync_trunk_enterprise` definition to clearly specify its purpose for enterprise edition images.
* Modified the `image_copy_rules` to deliver enterprise edition images (`sync_trunk_enterprise`) for `tidb`, `br`, and `tidb-lightning` to `gcr.io/pingcap-public/dbaas`, and community edition images to `docker.io/pingcap`. [[1]](diffhunk://#diff-95b19687ffd73deffa23edebbb4b0a94ba865cb9c854c36a77281c93703822e6L122-R128) [[2]](diffhunk://#diff-95b19687ffd73deffa23edebbb4b0a94ba865cb9c854c36a77281c93703822e6L141-R149) [[3]](diffhunk://#diff-95b19687ffd73deffa23edebbb4b0a94ba865cb9c854c36a77281c93703822e6L160-R170)
* Added a new rule to deliver enterprise edition `dumpling` images to `docker.io/pingcap/dumpling`, alongside the existing community edition rule.