### PR TITLE
feat(packages): add tiup component packaging and artifact definitions

### DIFF
--- a/dockerfiles/cd/builders/tiflash/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tiflash/centos7/Dockerfile
@@ -49,7 +49,6 @@ RUN --mount=type=cache,target=/var/cache/yum \
     echo "builder ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/builder
 USER builder
 
-
 ########### stage: building
 FROM builder AS building
 

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2999,7 +2999,7 @@ components:
               - { name: tiup-server, src : { path: bin/tiup-server } }
             tiup:
               description: Bootstrap a local TiDB cluster for fun.
-              entrypoint: tiup-dm
+              entrypoint: tiup-playground
           - name: "server-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
             files:
               - { name: tiup-server, src : { path: bin/tiup-server } }

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2940,3 +2940,69 @@ components:
             files: # prepare for context
               - { name: meta_service_server, src : { path: target/release/meta_service_server } }
               - { name: worker_node_server, src : { path: target/release/worker_node_server } }
+  tiup:
+    desc: tiup components tarballs and images
+    git:
+      # In the future, the repo will be open source in the `pingcap` ORG.
+      url: https://github.com/pingcap/tiup.git
+      ref: {{ .Git.ref | default "main" }}
+      sha: {{ .Git.sha | default "" }}
+    version: {{ .Release.version }} # segment version.
+    artifactory:
+      package_repo: "{{ .Release.registry }}/pingcap/tiup/package"
+      tags:
+        {{- if .Git.sha }}
+        - {{ strings.ReplaceAll "/" "-" .Git.ref | strings.ToLower }}-{{ strings.Trunc 7 .Git.sha }}
+        {{- end }}
+        - {{ strings.ReplaceAll "/" "-" .Git.ref | strings.ToLower }}
+        - {{ .Release.version }}
+    # binary builder, also we need it when build for mac to get build tools versions and other informations.
+    builders:
+      - image: ghcr.io/pingcap-qe/cd/builders/tici:v2025.7.13-4-g801199f-centos7
+    routers:
+      - description: currently in demo stage
+        os: [linux]
+        arch: [amd64, arm64]
+        profile: [release]
+        steps:
+          release:
+            - script: |
+                make build
+        artifacts:
+          - name: "tiup-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files:
+              - { name: tiup, src : { path: bin/tiup } }
+            tiup:
+              description: >-
+                TiUP is a command-line component management tool that can help to download and install TiDB platform components to the local system.
+              entrypoint: tiup
+          - name: "client-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files:
+              - { name: tiup-client, src : { path: bin/tiup-client } }
+            tiup:
+              description: Client to connect playground.
+              entrypoint: tiup-client
+          - name: "cluster-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files:
+              - { name: tiup-cluster, src : { path: bin/tiup-cluster } }
+            tiup:
+              description: Deploy a TiDB cluster for production
+              entrypoint: tiup-cluster
+          - name: "dm-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files:
+              - { name: tiup-dm, src : { path: bin/tiup-dm } }
+            tiup:
+              description: Data Migration Platform manager
+              entrypoint: tiup-dm
+          - name: "playground-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files:
+              - { name: tiup-server, src : { path: bin/tiup-server } }
+            tiup:
+              description: Bootstrap a local TiDB cluster for fun.
+              entrypoint: tiup-dm
+          - name: "server-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            files:
+              - { name: tiup-server, src : { path: bin/tiup-server } }
+            tiup:
+              description: TiUP publish/cache server
+              entrypoint: tiup-server


### PR DESCRIPTION
This pull request adds a new `tiup` component to the `packages.yaml.tmpl` configuration, enabling support for building, packaging, and distributing TiUP and its related binaries. The changes provide metadata, build instructions, artifact definitions, and descriptions for several TiUP subcomponents.

**Addition of TiUP packaging and distribution:**

* Introduced a new `tiup` section under `components:` in `packages/packages.yaml.tmpl`, including metadata such as repo URL, git reference, SHA, versioning, and artifactory settings for package distribution.
* Defined build instructions and builder images for TiUP, specifying the use of the `tici` builder image for Linux platforms and supported architectures.

**Artifact and subcomponent definitions:**

* Added artifact definitions for TiUP and its subcomponents (`tiup`, `client`, `cluster`, `dm`, `playground`, and `server`), each with their own file mappings, descriptions, and entrypoints for packaging and distribution.
* Provided detailed descriptions for each TiUP subcomponent, clarifying their roles (e.g., cluster deployment, data migration, playground setup, publish/cache server).