### PR TITLE
feat(dockerfiles/bases): add pingcap user and group to base Dockerfile

### DIFF
--- a/dockerfiles/bases/pingcap-base/Dockerfile
+++ b/dockerfiles/bases/pingcap-base/Dockerfile
@@ -1,3 +1,9 @@
 FROM quay.io/rockylinux/rockylinux:9.5.20241118
 COPY --from=busybox:1.37.0 /bin/busybox /bin/busybox
 RUN _date=20240730 dnf upgrade -y && dnf clean all
+
+# Add user and group to support run it with non-root.
+ARG PINGCAP_UID=1000
+ARG PINGCAP_GID=2000
+RUN groupadd -g ${PINGCAP_GID} pingcap && \
+    useradd -u ${PINGCAP_UID} -g ${PINGCAP_GID} -m pingcap

--- a/dockerfiles/bases/skaffold.yaml
+++ b/dockerfiles/bases/skaffold.yaml
@@ -53,7 +53,7 @@ build:
         dockerfile: tools-base/Dockerfile
   tagPolicy:
     customTemplate:
-      template: "v1.9.2"
+      template: "v1.10.0"
   local:
     useDockerCLI: true
     useBuildkit: true


### PR DESCRIPTION
- Create user and group in `pingcap-base` image.
- Update skaffold tag template to v1.10.0.