### PR TITLE
chore(dockerfiles/bases/tikv-base): bump base image and tag to v1.10.0

### DIFF
--- a/dockerfiles/bases/skaffold.yaml
+++ b/dockerfiles/bases/skaffold.yaml
@@ -73,7 +73,7 @@ build:
         dockerfile: tikv-base/fips.Dockerfile
   tagPolicy:
     customTemplate:
-      template: "v1.9.2-fips"
+      template: "v1.10.0-fips"
   local:
     useDockerCLI: true
     useBuildkit: true

--- a/dockerfiles/bases/tikv-base/fips.Dockerfile
+++ b/dockerfiles/bases/tikv-base/fips.Dockerfile
@@ -1,4 +1,4 @@
-ARG PINGCAP_BASE=ghcr.io/pingcap-qe/bases/pingcap-base:v1.9.2
+ARG PINGCAP_BASE=ghcr.io/pingcap-qe/bases/pingcap-base:v1.10.0
 FROM $PINGCAP_BASE
 # wget is requested by operator
 RUN dnf install -y tzdata wget openssl && dnf clean all


### PR DESCRIPTION
for FIPS build