### PR TITLE
feat(packages/scripts): add multi-arch image collection and push support

### DIFF
--- a/packages/scripts/build-package-images.sh.tmpl
+++ b/packages/scripts/build-package-images.sh.tmpl
@@ -37,6 +37,7 @@ parse_arguments() {
   NEED_BUILD_BIN="false" # Default value is false
   NEED_PUSH_IMAGE="true" # Default value is true
   NEED_TAG_MORE="false" # Default value is false
+  NEED_COLLECT_MULT_ARCH="false" # Default value is false
   KANIKO_EXECUTOR="/kaniko/executor"
   PUSH_RESULT_SAVE_FILE="result-images.yaml"
 
@@ -60,6 +61,10 @@ parse_arguments() {
         ;;
       -t)
         NEED_TAG_MORE="true"
+        shift
+        ;;
+      -m)
+        NEED_COLLECT_MULT_ARCH="true"
         shift
         ;;
       -k)
@@ -91,6 +96,7 @@ print_help() {
   echo "  -p                  Enable build and push images (default true)"
   echo "  -P                  Skip build and push images (default true)"
   echo "  -t                  Enable add more tags, else just pushed for first tag (default false)"
+  echo "  -m                  Enable collect and push multi-arch images (default false)"
   echo "  -k kaniko_executor  Set the Kaniko executor path (default: '/kaniko/executor')"
   echo "  -h                  Print this help message"
 }
@@ -217,14 +223,20 @@ build_and_push_images() {
     cat "$digests_file"
 }
 
-{{- $tag_suffix := printf "_%s_%s" .os .arch }}
+{{- $tag_suffix := "" }}
 {{- if ne .profile "release" }}
-{{- $tag_suffix = printf "-%s_%s_%s" .profile .os .arch }}
+{{- $tag_suffix = printf "-%s" .profile }}
+{{- end }}
+{{- $platform_tag_suffix := printf "%s_%s_%s" $tag_suffix .os .arch }}
+
+{{- $base_tags := coll.Slice }}
+{{- range $index, $tag := .artifactory.tags }}
+{{- $base_tags = append (printf "%s%s" $tag $tag_suffix) $base_tags }}
 {{- end }}
 
 {{- $tags := coll.Slice }}
-{{- range $index, $tag := .artifactory.tags }}
-{{- $tags = append (printf "%s%s" $tag $tag_suffix) $tags }}
+{{- range $index, $tag := $base_tags }}
+{{- $tags = append (printf "%s%s" $tag $platform_tag_suffix) $tags }}
 {{- end }}
 
 # Write results to file.
@@ -252,6 +264,28 @@ add_more_tags() {
     {{- end }}
     {{- else }}
     echo "🤷 No more tags need to be taged."
+    {{- end }}
+}
+
+collect_and_push_multi_arch_images() {
+    {{- $self_tag := index $tags 0 }}
+    {{- $other_arch := ternary "arm64" "amd64" (eq .arch "amd64") }}
+    {{- $other_tag := printf "%s_%s_%s" (index $base_tags 0) .os $other_arch }}
+
+    {{- range $index, $image := (.artifacts | jq `map(select(.type == "image" and .if != false))`) }}
+
+    # 📦 try to collect and push multi-arch image: {{ $image.artifactory.repo }}:{{ index $tags 0 }}
+        {{- range $i, $tag := $base_tags }}
+            {{- if eq $i 0 }}
+    if ! crane digest {{ $image.artifactory.repo }}:{{ $other_tag }}; then
+        echo "Image {{ $image.artifactory.repo }}:{{ $other_tag }} not found."
+        exit 0
+    fi
+    crane index append -m {{ $image.artifactory.repo }}:{{ $self_tag }} -m {{ $image.artifactory.repo }}:{{ $other_tag }} -t {{ $image.artifactory.repo }}:{{ $tag }}
+            {{- else }}
+    crane tag {{ $image.artifactory.repo }}:{{ index $base_tags 0 }} {{ $tag }}
+            {{- end }}
+        {{- end }}
     {{- end }}
 }
 


### PR DESCRIPTION
Let's make it can work standalone without event driven.
- In pushing to google cloud artifacts repo, it's too complex and expensive to introduce the Pub/Sub stack.
- After this refactoring, it can work in IDC Clusters or any other cloud clusters.
- Previously, we compute the multi-arch tags in another task/scripts, it make the logic not atomically with the `packages.yaml.tmpl` file, it will solve it.