### PR TITLE
refactor(packages/scripts): refactor image result file handling and multi-arch tagging

### DIFF
--- a/packages/scripts/build-package-images.sh.tmpl
+++ b/packages/scripts/build-package-images.sh.tmpl
@@ -293,7 +293,7 @@ collect_and_push_multi_arch_images() {
     crane tag {{ $image.artifactory.repo }}:{{ index $base_tags 0 }} {{ $tag }}
             {{- end }}
         {{- end }}
-    yq -i '.images[{{ $index }}].multi-arch-tags = ["{{ join $base_tags "\",\"" }}"]' "$result_file"
+    yq -i '.images[{{ $index }}].multi_arch_tags = ["{{ join $base_tags "\",\"" }}"]' "$result_file"
     {{- end }}
 
     echo "✅ Multi-arch images recorded in file: $result_file"

--- a/packages/scripts/build-package-images.sh.tmpl
+++ b/packages/scripts/build-package-images.sh.tmpl
@@ -26,12 +26,12 @@ main() {
 
   # push other tags
   if [ "$NEED_TAG_MORE" = "true" ]; then
-    add_more_tags
+    add_more_tags "${PUSH_RESULT_SAVE_FILE}"
   fi
 
   # collect and push multi-arch images
   if [ "$NEED_COLLECT_MULT_ARCH" = "true" ]; then
-    collect_and_push_multi_arch_images "${MULTI_ARCH_RESULT_SAVE_FILE}"
+    collect_and_push_multi_arch_images "${PUSH_RESULT_SAVE_FILE}"
   fi
 
   echo "✅ All done"
@@ -45,7 +45,6 @@ parse_arguments() {
   NEED_COLLECT_MULT_ARCH="false" # Default value is false
   KANIKO_EXECUTOR="/kaniko/executor"
   PUSH_RESULT_SAVE_FILE="result-images.yaml"
-  MULTI_ARCH_RESULT_SAVE_FILE="multi-arch-images.yaml" # Default value for multi-arch results
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -81,10 +80,6 @@ parse_arguments() {
         PUSH_RESULT_SAVE_FILE="$2"
         shift 2
         ;;
-      -M)
-        MULTI_ARCH_RESULT_SAVE_FILE="$2"
-        shift 2
-        ;;
       -h)
         print_help
         exit 0
@@ -102,7 +97,6 @@ print_help() {
   echo "Options:"
   echo "  -w release_ws       Set the release workspace (default: 'build')"
   echo "  -o result_path      Set the result path (default: 'result-images.yaml')"
-  echo "  -M multi_arch_result Set the multi-arch result path (default: 'multi-arch-images.yaml')"
   echo "  -b                  Enable building binaries (default false)"
   echo "  -p                  Enable build and push images (default true)"
   echo "  -P                  Skip build and push images (default true)"
@@ -268,10 +262,12 @@ EOF
 }
 
 add_more_tags() {
+    result_file="$1"
+
     {{- if gt (len $tags) 1 }}
-    # add other tags.
     {{- range $index, $image := (.artifacts | jq `map(select(.type == "image" and .if != false))`) }}
     oras tag {{ $image.artifactory.repo }}:{{ join $tags " " }}
+    yq -i '.images[{{ $index }}].tags = ["{{ join $tags "\",\"" }}"]' "$result_file"
     {{- end }}
     {{- else }}
     echo "🤷 No more tags need to be taged."
@@ -283,10 +279,6 @@ collect_and_push_multi_arch_images() {
     {{- $self_tag := index $tags 0 }}
     {{- $other_arch := ternary "arm64" "amd64" (eq .arch "amd64") }}
     {{- $other_tag := printf "%s_%s_%s" (index $base_tags 0) .os $other_arch }}
-
-    # Initialize the result file with empty multi_arch_images array
-    echo "multi_arch_images: []" > "$result_file"
-
     {{- range $index, $image := (.artifacts | jq `map(select(.type == "image" and .if != false))`) }}
 
     # 📦 try to collect and push multi-arch image: {{ $image.artifactory.repo }}:{{ index $base_tags 0 }}
@@ -301,21 +293,7 @@ collect_and_push_multi_arch_images() {
     crane tag {{ $image.artifactory.repo }}:{{ index $base_tags 0 }} {{ $tag }}
             {{- end }}
         {{- end }}
-
-    # Use yq to add the image info to the result file
-    # Create a temporary YAML snippet for this image
-    temp_yaml_snippet=$(mktemp)
-    cat <<EOF > "$temp_yaml_snippet"
-- repo: {{ $image.artifactory.repo }}
-  tags:
-    {{- range $tag := $base_tags }}
-    - "{{ $tag }}"
-    {{- end }}
-EOF
-
-    # Merge the temporary YAML into the result file
-    yq eval ".multi_arch_images += load(\"$temp_yaml_snippet\")" -i "$result_file"
-    rm -f "$temp_yaml_snippet"
+    yq -i '.images[{{ $index }}].multi-arch-tags = ["{{ join $base_tags "\",\"" }}"]' "$result_file"
     {{- end }}
 
     echo "✅ Multi-arch images recorded in file: $result_file"


### PR DESCRIPTION

- Remove separate multi-arch result file logic
- Consolidate all image tag results into PUSH_RESULT_SAVE_FILE
- Update yq commands to write multi-arch tags to unified result file
- Simplify argument parsing and help output