### PR TITLE
refactor(packages/scripts): update build script to remove redundant image URL field

### DIFF
--- a/packages/scripts/build-package-images.sh.tmpl
+++ b/packages/scripts/build-package-images.sh.tmpl
@@ -254,7 +254,6 @@ write_push_results() {
 images:
 {{- range $index, $image := (.artifacts | jq `map(select(.type == "image" and .if != false))`) }}
 - repo: {{ $image.artifactory.repo }}
-  url: "{{ $image.artifactory.repo }}:$primary_tag"
   tag: "$primary_tag"
   digest: '$(sed -n "{{ add $index 1 }}p" $input_disgests_file)'
 {{- end }}


### PR DESCRIPTION

The URL field was duplicating information already present in the repo and tag fields, making the output cleaner and less redundant.