### PR TITLE
feat(dockerfiles/bases): add debugging base Dockerfile and structure tests skeleton

### DIFF
--- a/dockerfiles/bases/debugging/Dockerfile
+++ b/dockerfiles/bases/debugging/Dockerfile
@@ -5,7 +5,7 @@ FROM $PINGCAP_BASE
 RUN --mount=type=cache,id=dnf-cache,target=/var/cache/dnf \
     dnf install -y epel-release && \
     # 🔧 General System Inspection: procps-ng htop iotop atop dstat lsof perf
-    # dnf install -y procps-ng htop iotop atop dstat lsof  perf && \  
+    # dnf install -y procps-ng htop iotop atop dstat lsof  perf && \
     # 🖥 CPU & Performance
     dnf install -y sysstat stress && \
     # 💾 Memory
@@ -17,7 +17,7 @@ RUN --mount=type=cache,id=dnf-cache,target=/var/cache/dnf \
     # 🐛 Debugging / Tracing
     dnf install -y  gdb bpftrace bcc strace ltrace && \
     # 🧰 Useful Misc
-    dnf install -y file vim-common jq nmap-ncat socat tmux ripgrep 
+    dnf install -y file vim-common jq nmap-ncat socat tmux ripgrep
 
 # Install addition perf-tools
 ADD --chmod=755 https://raw.githubusercontent.com/brendangregg/perf-tools/master/iosnoop /usr/local/bin/

--- a/dockerfiles/bases/debugging/Dockerfile
+++ b/dockerfiles/bases/debugging/Dockerfile
@@ -3,21 +3,21 @@ FROM $PINGCAP_BASE
 
 # Install packages with package manager.
 RUN --mount=type=cache,id=dnf-cache,target=/var/cache/dnf \
-    dnf install -y epel-release && \
+    dnf install -y epel-release && dnf install -y \
     # 🔧 General System Inspection: procps-ng htop iotop atop dstat lsof perf
-    dnf install -y procps-ng htop iotop atop dstat lsof  perf && \
+    procps-ng htop iotop atop dstat lsof  perf \
     # 🖥 CPU & Performance
-    dnf install -y sysstat stress && \
+    sysstat stress \
     # 💾 Memory
-    dnf install -y smem numactl valgrind && \
+    smem numactl valgrind \
     # 📀 Disk / IO
-    dnf install -y blktrace fio && \
+    blktrace fio \
     # 🌐 Network
-    dnf install -y iftop nethogs net-tools tcpdump iperf3 bind-utils ethtool traceroute mtr && \
+    iftop nethogs net-tools tcpdump iperf3 bind-utils ethtool traceroute mtr \
     # 🐛 Debugging / Tracing
-    dnf install -y  gdb bpftrace bcc strace ltrace && \
+    gdb bpftrace bcc strace ltrace \
     # 🧰 Useful Misc
-    dnf install -y file vim-common jq nmap-ncat socat tmux ripgrep
+    file vim-common jq nmap-ncat socat tmux ripgrep
 
 # Install addition perf-tools
 ADD --chmod=755 https://raw.githubusercontent.com/brendangregg/perf-tools/master/iosnoop /usr/local/bin/

--- a/dockerfiles/bases/debugging/Dockerfile
+++ b/dockerfiles/bases/debugging/Dockerfile
@@ -19,5 +19,6 @@ RUN --mount=type=cache,id=dnf-cache,target=/var/cache/dnf \
     # 🧰 Useful Misc
     file vim-common jq nmap-ncat socat tmux ripgrep
 
-# Install addition perf-tools
-ADD --chmod=755 https://raw.githubusercontent.com/brendangregg/perf-tools/master/iosnoop /usr/local/bin/
+# Install addition perf-tools into /opt/perf-tools folder.
+RUN curl -L https://github.com/brendangregg/perf-tools/archive/refs/heads/master.tar.gz | tar -xz -C /opt && \
+    mv /opt/perf-tools-master /opt/perf-tools

--- a/dockerfiles/bases/debugging/Dockerfile
+++ b/dockerfiles/bases/debugging/Dockerfile
@@ -1,0 +1,72 @@
+ARG PINGCAP_BASE
+FROM $PINGCAP_BASE
+
+# 📄 Core text / navigation tools: ripgrep
+# 🔧 General System Inspection: procps-ng htop iotop atop dstat lsof strace perf
+RUN --mount=type=cache,id=dnf-cache,target=/var/cache/dnf \
+    dnf install -y epel-release && \
+    dnf install -y \
+    ripgrep
+# procps-ng htop iotop atop dstat lsof strace perf
+
+### 🖥 **CPU & Performance**
+
+# * `mpstat` (from `sysstat`) → per-CPU utilization
+# * `pidstat` → per-process CPU, memory, IO
+# * `stress` or `stress-ng` → load generator for CPU/memory/disk/network
+# * `perf-tools` (e.g., `funccount`, `execsnoop`) → deeper kernel/CPU tracing
+
+
+### 💾 **Memory**
+
+# * `free` → quick memory usage
+# * `smem` → memory usage per process with shared memory reporting
+# * `pmap` → process memory map
+# * `numastat` → NUMA memory stats
+# * `valgrind` (optional, heavy) → memory debugging / leaks (useful for dev builds)
+
+
+### 📀 **Disk / IO**
+
+# * `iotop` → IO usage
+# * `iostat` (from `sysstat`) → block device IO
+# * `blktrace` + `blkparse` → detailed block-level tracing
+# * `fio` → flexible IO workload generator
+# * `dd` → quick read/write speed tests
+# * `lsblk`, `df`, `du` → disk layout and usage
+
+
+### 🌐 **Network**
+
+# * `iftop` → live network usage per connection
+# * `nethogs` → per-process bandwidth
+# * `ss` / `netstat` → socket statistics
+# * `tcpdump` → packet capture
+# * `iperf3` → network throughput testing
+# * `dig`, `curl`, `wget` → DNS/HTTP testing
+# * `ethtool` → NIC statistics
+# * `traceroute`, `mtr` → path and latency diagnostics
+
+### 🐛 **Debugging / Tracing**
+
+# * `gdb` → debugger
+# * `bpftrace` / `bcc` tools (if kernel supports it) → powerful tracing
+# * `strace` / `ltrace` → syscall and library call tracing
+
+### 🧰 **Useful Misc**
+
+# * `busybox` → Swiss army knife for small utilities
+# * `file` → check file types
+# * `hexdump` / `xxd` → binary inspection
+# * `jq` → JSON parser (for logs and configs)
+# * `nc` / `socat` → networking testing
+# * `tmux` → for long-running debug sessions inside container
+
+
+### 🏢 **Company Tools**
+# * TiUp
+
+# if you want tidb-ctl, pd-ctl, tikv-ctl tool, you can install them with tiup tool:
+# tiup tidb-ctl ...
+
+# mok / tiup  / rg /

--- a/dockerfiles/bases/debugging/Dockerfile
+++ b/dockerfiles/bases/debugging/Dockerfile
@@ -5,7 +5,7 @@ FROM $PINGCAP_BASE
 RUN --mount=type=cache,id=dnf-cache,target=/var/cache/dnf \
     dnf install -y epel-release && \
     # 🔧 General System Inspection: procps-ng htop iotop atop dstat lsof perf
-    dnf install -y procps-ng htop iotop atop dstat lsof  perf && \  
+    dnf install -y procps-ng htop iotop atop dstat lsof  perf && \
     # 🖥 CPU & Performance
     dnf install -y sysstat stress && \
     # 💾 Memory

--- a/dockerfiles/bases/debugging/Dockerfile
+++ b/dockerfiles/bases/debugging/Dockerfile
@@ -5,7 +5,7 @@ FROM $PINGCAP_BASE
 RUN --mount=type=cache,id=dnf-cache,target=/var/cache/dnf \
     dnf install -y epel-release && \
     # 🔧 General System Inspection: procps-ng htop iotop atop dstat lsof perf
-    # dnf install -y procps-ng htop iotop atop dstat lsof  perf && \
+    dnf install -y procps-ng htop iotop atop dstat lsof  perf && \  
     # 🖥 CPU & Performance
     dnf install -y sysstat stress && \
     # 💾 Memory

--- a/dockerfiles/bases/debugging/Dockerfile
+++ b/dockerfiles/bases/debugging/Dockerfile
@@ -1,72 +1,23 @@
 ARG PINGCAP_BASE
 FROM $PINGCAP_BASE
 
-# 📄 Core text / navigation tools: ripgrep
-# 🔧 General System Inspection: procps-ng htop iotop atop dstat lsof strace perf
+# Install packages with package manager.
 RUN --mount=type=cache,id=dnf-cache,target=/var/cache/dnf \
     dnf install -y epel-release && \
-    dnf install -y \
-    ripgrep
-# procps-ng htop iotop atop dstat lsof strace perf
+    # 🔧 General System Inspection: procps-ng htop iotop atop dstat lsof perf
+    # dnf install -y procps-ng htop iotop atop dstat lsof  perf && \  
+    # 🖥 CPU & Performance
+    dnf install -y sysstat stress && \
+    # 💾 Memory
+    dnf install -y smem numactl valgrind && \
+    # 📀 Disk / IO
+    dnf install -y blktrace fio && \
+    # 🌐 Network
+    dnf install -y iftop nethogs net-tools tcpdump iperf3 bind-utils ethtool traceroute mtr && \
+    # 🐛 Debugging / Tracing
+    dnf install -y  gdb bpftrace bcc strace ltrace && \
+    # 🧰 Useful Misc
+    dnf install -y file vim-common jq nmap-ncat socat tmux ripgrep 
 
-### 🖥 **CPU & Performance**
-
-# * `mpstat` (from `sysstat`) → per-CPU utilization
-# * `pidstat` → per-process CPU, memory, IO
-# * `stress` or `stress-ng` → load generator for CPU/memory/disk/network
-# * `perf-tools` (e.g., `funccount`, `execsnoop`) → deeper kernel/CPU tracing
-
-
-### 💾 **Memory**
-
-# * `free` → quick memory usage
-# * `smem` → memory usage per process with shared memory reporting
-# * `pmap` → process memory map
-# * `numastat` → NUMA memory stats
-# * `valgrind` (optional, heavy) → memory debugging / leaks (useful for dev builds)
-
-
-### 📀 **Disk / IO**
-
-# * `iotop` → IO usage
-# * `iostat` (from `sysstat`) → block device IO
-# * `blktrace` + `blkparse` → detailed block-level tracing
-# * `fio` → flexible IO workload generator
-# * `dd` → quick read/write speed tests
-# * `lsblk`, `df`, `du` → disk layout and usage
-
-
-### 🌐 **Network**
-
-# * `iftop` → live network usage per connection
-# * `nethogs` → per-process bandwidth
-# * `ss` / `netstat` → socket statistics
-# * `tcpdump` → packet capture
-# * `iperf3` → network throughput testing
-# * `dig`, `curl`, `wget` → DNS/HTTP testing
-# * `ethtool` → NIC statistics
-# * `traceroute`, `mtr` → path and latency diagnostics
-
-### 🐛 **Debugging / Tracing**
-
-# * `gdb` → debugger
-# * `bpftrace` / `bcc` tools (if kernel supports it) → powerful tracing
-# * `strace` / `ltrace` → syscall and library call tracing
-
-### 🧰 **Useful Misc**
-
-# * `busybox` → Swiss army knife for small utilities
-# * `file` → check file types
-# * `hexdump` / `xxd` → binary inspection
-# * `jq` → JSON parser (for logs and configs)
-# * `nc` / `socat` → networking testing
-# * `tmux` → for long-running debug sessions inside container
-
-
-### 🏢 **Company Tools**
-# * TiUp
-
-# if you want tidb-ctl, pd-ctl, tikv-ctl tool, you can install them with tiup tool:
-# tiup tidb-ctl ...
-
-# mok / tiup  / rg /
+# Install addition perf-tools
+ADD --chmod=755 https://raw.githubusercontent.com/brendangregg/perf-tools/master/iosnoop /usr/local/bin/

--- a/dockerfiles/bases/debugging/structure-test/test.yaml
+++ b/dockerfiles/bases/debugging/structure-test/test.yaml
@@ -43,11 +43,11 @@ commandTests:
   - name: "vmstat from procps present"
     command: "command"
     args: ["-v", "vmstat"]
-    exitCode: 0    
+    exitCode: 0
   - name: "free from procps present"
     command: "command"
     args: ["-v", "free"]
-    exitCode: 0    
+    exitCode: 0
 
   - name: "htop present"
     command: "command"
@@ -82,7 +82,7 @@ commandTests:
   - name: "dstat present"
     command: "command"
     args: ["-v", "dstat"]
-    exitCode: 0    
+    exitCode: 0
 
 
 
@@ -138,7 +138,7 @@ commandTests:
   - name: "valgrind present"
     command: "command"
     args: ["-v", "valgrind"]
-    exitCode: 0    
+    exitCode: 0
 
   #######################################################################
   # Future: Debugging / Tracing
@@ -159,7 +159,7 @@ commandTests:
   #######################################################################
   # 4. Future: Disk / IO
   #######################################################################
-  
+
   - name: "fio present"
     command: "command"
     args: ["-v", "fio"]

--- a/dockerfiles/bases/debugging/structure-test/test.yaml
+++ b/dockerfiles/bases/debugging/structure-test/test.yaml
@@ -1,0 +1,138 @@
+# Container Structure Tests for debugging base image
+# File: artifacts/dockerfiles/bases/debugging/tests/debugging_image_test.yaml
+#
+# Purpose:
+# This suite is intentionally minimal right now because the Dockerfile
+# (debugging image) has not yet had the debugging / observability tools
+# installed. It establishes a foundation you can safely run in CI
+# immediately, then you can progressively (uncomment / add) tests as you
+# add each category of tooling.
+#
+# How to run (example):
+#   container-structure-test test \
+#     --image <your-built-image> \
+#     --config artifacts/dockerfiles/bases/debugging/structure-test/test.yaml
+#
+# Add new tests by:
+#  1. Installing tools in the Dockerfile.
+#  2. Uncommenting / adding relevant commandTests or fileExistenceTests.
+#  3. Keeping assertions narrowly scoped (e.g. just --version grep) so
+#     updates to package minor versions don't cause needless failures.
+#
+# Documentation:
+#   https://github.com/GoogleContainerTools/container-structure-test
+
+schemaVersion: 2.0.0
+
+commandTests:
+  #######################################################################
+  # 1. Future: Core text / navigation tools
+  #######################################################################
+  # Uncomment as you add these packages (e.g., via apt, yum, apk).
+  - name: "less installed"
+    command: ["sh", "-c", "command -v less"]
+    expectedError: []
+    exitCode: 0
+
+  - name: "vim minimal present"
+    command: ["sh", "-c", "command -v vim || command -v vi"]
+    exitCode: 0
+
+  - name: "ripgrep (rg) available"
+    command: ["sh", "-c", "command -v rg"]
+    exitCode: 0
+
+  #######################################################################
+  # 2. Future: System inspection & performance tools
+  #######################################################################
+  - name: "ps from procps present"
+    command: ["sh", "-c", "command -v ps"]
+    exitCode: 0
+
+  - name: "htop present"
+    command: ["sh", "-c", "command -v htop"]
+    exitCode: 0
+
+  - name: "lsof present"
+    command: ["sh", "-c", "command -v lsof"]
+    exitCode: 0
+
+  - name: "strace present"
+    command: ["sh", "-c", "command -v strace"]
+    exitCode: 0
+
+  #######################################################################
+  # 3. Future: CPU / perf / tracing
+  #######################################################################
+  - name: "perf tool installed"
+    command: ["sh", "-c", "command -v perf"]
+    exitCode: 0
+
+  - name: "bpftrace present"
+    command: ["sh", "-c", "command -v bpftrace"]
+    exitCode: 0
+
+  - name: "gdb present"
+    command: ["sh", "-c", "command -v gdb"]
+    exitCode: 0
+
+  #######################################################################
+  # 4. Future: Memory / IO / Disk
+  #######################################################################
+  - name: "smem present"
+    command: ["sh", "-c", "command -v smem"]
+    exitCode: 0
+
+  - name: "fio present"
+    command: ["sh", "-c", "command -v fio"]
+    exitCode: 0
+
+  - name: "iostat (sysstat) present"
+    command: ["sh", "-c", "command -v iostat"]
+    exitCode: 0
+
+  #######################################################################
+  # 5. Future: Network diagnostics
+  #######################################################################
+  - name: "curl present"
+    command: ["sh", "-c", "command -v curl"]
+    exitCode: 0
+
+  - name: "tcpdump present"
+    command: ["sh", "-c", "command -v tcpdump"]
+    exitCode: 0
+
+  - name: "iperf3 present"
+    command: ["sh", "-c", "command -v iperf3"]
+    exitCode: 0
+
+  #######################################################################
+  # 6. Future: JSON, hex, misc tools
+  #######################################################################
+  - name: "jq present"
+    command: ["sh", "-c", "command -v jq"]
+    exitCode: 0
+
+  - name: "xxd present"
+    command: ["sh", "-c", "command -v xxd || command -v hexdump"]
+    exitCode: 0
+
+  - name: "tmux present"
+    command: ["sh", "-c", "command -v tmux"]
+    exitCode: 0
+
+  #######################################################################
+  # 7. Future: TiUP & TiDB ecosystem utilities
+  #######################################################################
+  - name: "tiup present"
+    command: ["sh", "-c", "command -v tiup"]
+    exitCode: 0
+  - name: "tiup can install and run ctl components - tidb"
+    command: ["sh", "-c", "tiup ctl:v8.5.3 tidb help"]
+    exitCode: 0
+  - name: "tiup can install and run ctl components - pd"
+    command: ["sh", "-c", "tiup ctl:v8.5.3 pd help"]
+    exitCode: 0
+  - name: "tiup can install and run ctl components - tikv"
+    command: ["sh", "-c", "tiup ctl:v8.5.3 tikv help"]
+    exitCode: 0

--- a/dockerfiles/bases/debugging/structure-test/test.yaml
+++ b/dockerfiles/bases/debugging/structure-test/test.yaml
@@ -26,113 +26,222 @@ schemaVersion: 2.0.0
 
 commandTests:
   #######################################################################
-  # 1. Future: Core text / navigation tools
-  #######################################################################
-  # Uncomment as you add these packages (e.g., via apt, yum, apk).
-  - name: "less installed"
-    command: ["sh", "-c", "command -v less"]
-    expectedError: []
-    exitCode: 0
-
-  - name: "vim minimal present"
-    command: ["sh", "-c", "command -v vim || command -v vi"]
-    exitCode: 0
-
-  - name: "ripgrep (rg) available"
-    command: ["sh", "-c", "command -v rg"]
-    exitCode: 0
-
-  #######################################################################
-  # 2. Future: System inspection & performance tools
+  # Future: General System Inspection
   #######################################################################
   - name: "ps from procps present"
-    command: ["sh", "-c", "command -v ps"]
+    command: "command"
+    args: ["-v", "ps"]
     exitCode: 0
+  - name: "top from procps present"
+    command: "command"
+    args: ["-v", "top"]
+    exitCode: 0
+  - name: "uptime from procps present"
+    command: "command"
+    args: ["-v", "uptime"]
+    exitCode: 0
+  - name: "vmstat from procps present"
+    command: "command"
+    args: ["-v", "vmstat"]
+    exitCode: 0    
+  - name: "free from procps present"
+    command: "command"
+    args: ["-v", "free"]
+    exitCode: 0    
 
   - name: "htop present"
-    command: ["sh", "-c", "command -v htop"]
+    command: "command"
+    args: ["-v", "htop"]
+    exitCode: 0
+
+  - name: "iotop present"
+    command: "command"
+    args: ["-v", "iotop"]
+    exitCode: 0
+
+  - name: "atop present"
+    command: "command"
+    args: ["-v", "atop"]
     exitCode: 0
 
   - name: "lsof present"
-    command: ["sh", "-c", "command -v lsof"]
+    command: "command"
+    args: ["-v", "lsof"]
     exitCode: 0
 
   - name: "strace present"
-    command: ["sh", "-c", "command -v strace"]
+    command: "command"
+    args: ["-v", "strace"]
     exitCode: 0
 
+  - name: "perf present"
+    command: "command"
+    args: ["-v", "perf"]
+    exitCode: 0
+
+  - name: "dstat present"
+    command: "command"
+    args: ["-v", "dstat"]
+    exitCode: 0    
+
+
+
+
+
   #######################################################################
-  # 3. Future: CPU / perf / tracing
+  # Future: CPU / perf / tracing
   #######################################################################
+  - name: "mpstat present"
+    command: "command"
+    args: ["-v", "mpstat"]
+
+  - name: "pidstat present"
+    command: "command"
+    args: ["-v", "pidstat"]
+
+  - name: "stress present"
+    command: "command"
+    args: ["-v", "stress"]
+
   - name: "perf tool installed"
-    command: ["sh", "-c", "command -v perf"]
+    command: "command"
+    args: ["-v", "perf"]
     exitCode: 0
 
-  - name: "bpftrace present"
-    command: ["sh", "-c", "command -v bpftrace"]
-    exitCode: 0
 
-  - name: "gdb present"
-    command: ["sh", "-c", "command -v gdb"]
-    exitCode: 0
+
+
 
   #######################################################################
-  # 4. Future: Memory / IO / Disk
+  # Future: Memory
   #######################################################################
+  - name: "free present"
+    command: "command"
+    args: ["-v", "free"]
+    exitCode: 0
+
+  - name: "pmap present"
+    command: "command"
+    args: ["-v", "pmap"]
+    exitCode: 0
+
+  - name: "numastat present"
+    command: "command"
+    args: ["-v", "numastat"]
+    exitCode: 0
+
   - name: "smem present"
-    command: ["sh", "-c", "command -v smem"]
+    command: "command"
+    args: ["-v", "smem"]
     exitCode: 0
 
+  - name: "valgrind present"
+    command: "command"
+    args: ["-v", "valgrind"]
+    exitCode: 0    
+
+  #######################################################################
+  # Future: Debugging / Tracing
+  #######################################################################
+  - name: "gdb present"
+    command: "command"
+    args: ["-v", "gdb"]
+    exitCode: 0
+  - name: "bpftrace present"
+    command: "command"
+    args: ["-v", "bpftrace"]
+    exitCode: 0
+  - name: "strace present"
+    command: "command"
+    args: ["-v", "strace"]
+    exitCode: 0
+
+  #######################################################################
+  # 4. Future: Disk / IO
+  #######################################################################
+  
   - name: "fio present"
-    command: ["sh", "-c", "command -v fio"]
+    command: "command"
+    args: ["-v", "fio"]
     exitCode: 0
 
   - name: "iostat (sysstat) present"
-    command: ["sh", "-c", "command -v iostat"]
+    command: "command"
+    args: ["-v", "iostat"]
     exitCode: 0
 
   #######################################################################
   # 5. Future: Network diagnostics
   #######################################################################
   - name: "curl present"
-    command: ["sh", "-c", "command -v curl"]
+    command: "command"
+    args: ["-v", "curl"]
     exitCode: 0
 
   - name: "tcpdump present"
-    command: ["sh", "-c", "command -v tcpdump"]
+    command: "command"
+    args: ["-v", "tcpdump"]
     exitCode: 0
 
   - name: "iperf3 present"
-    command: ["sh", "-c", "command -v iperf3"]
+    command: "command"
+    args: ["-v", "iperf3"]
     exitCode: 0
 
   #######################################################################
   # 6. Future: JSON, hex, misc tools
   #######################################################################
   - name: "jq present"
-    command: ["sh", "-c", "command -v jq"]
+    command: "command"
+    args: ["-v", "jq"]
     exitCode: 0
 
   - name: "xxd present"
-    command: ["sh", "-c", "command -v xxd || command -v hexdump"]
+    command: "sh"
+    args: ["sh", "-c", "command -v xxd || command -v hexdump"]
     exitCode: 0
 
   - name: "tmux present"
-    command: ["sh", "-c", "command -v tmux"]
+    command: "sh"
+    args: ["sh", "-c", "command -v tmux"]
     exitCode: 0
 
   #######################################################################
   # 7. Future: TiUP & TiDB ecosystem utilities
   #######################################################################
   - name: "tiup present"
-    command: ["sh", "-c", "command -v tiup"]
+    command: "command"
+    args: ["-v", "tiup"]
     exitCode: 0
   - name: "tiup can install and run ctl components - tidb"
-    command: ["sh", "-c", "tiup ctl:v8.5.3 tidb help"]
+    command: "tiup"
+    args: ["ctl:v8.5.3", "tidb", "help"]
     exitCode: 0
   - name: "tiup can install and run ctl components - pd"
-    command: ["sh", "-c", "tiup ctl:v8.5.3 pd help"]
+    command: "tiup"
+    args: ["ctl:v8.5.3", "pd", "help"]
     exitCode: 0
   - name: "tiup can install and run ctl components - tikv"
-    command: ["sh", "-c", "tiup ctl:v8.5.3 tikv help"]
+    command: "tiup"
+    args: ["ctl:v8.5.3", "tikv", "help"]
+    exitCode: 0
+
+
+  #######################################################################
+  # Future: Core text / navigation tools
+  #######################################################################
+  # Uncomment as you add these packages (e.g., via apt, yum, apk).
+  - name: "less installed"
+    command: "command"
+    args: ["-v", "less"]
+    exitCode: 0
+
+  - name: "vim minimal present"
+    command: "sh"
+    args: ["-c", "command -v vim || command -v vi"]
+    exitCode: 0
+
+  - name: "ripgrep (rg) available"
+    command: "command"
+    args: ["-v", "rg"]
     exitCode: 0

--- a/dockerfiles/bases/skaffold.yaml
+++ b/dockerfiles/bases/skaffold.yaml
@@ -51,6 +51,13 @@ build:
           alias: PINGCAP_BASE
       docker:
         dockerfile: tools-base/Dockerfile
+    - image: debugging
+      platforms: [linux/amd64, linux/arm64]
+      requires:
+        - image: pingcap-base
+          alias: PINGCAP_BASE
+      docker:
+        dockerfile: debugging/Dockerfile
   tagPolicy:
     customTemplate:
       template: "v1.10.0"


### PR DESCRIPTION
This pull request introduces a new debugging base image to the Docker build system, complete with a wide array of system inspection, debugging, and observability tools. It also adds a comprehensive container structure test suite to verify the presence and functionality of these tools. The Skaffold configuration is updated to build this new image for multiple architectures.

**Debugging Base Image and Tooling:**

* Added a new `debugging` Docker image (`dockerfiles/bases/debugging/Dockerfile`) that installs a broad set of system inspection, debugging, tracing, and observability tools (e.g., `htop`, `iotop`, `perf`, `gdb`, `bpftrace`, `fio`, `tcpdump`, `jq`, `tmux`, `ripgrep`, and more). Also includes the addition of Brendan Gregg's `iosnoop` perf tool.

**Testing and Verification:**

* Introduced a new container structure test suite (`dockerfiles/bases/debugging/structure-test/test.yaml`) that checks for the presence and basic functionality of all the installed debugging tools, including TiUP ecosystem utilities. This test suite is ready to be run in CI and is extensible as more tools are added.

**Build System Updates:**

* Updated the Skaffold configuration (`dockerfiles/bases/skaffold.yaml`) to build the new `debugging` image for both `linux/amd64` and `linux/arm64` platforms, using `pingcap-base` as its base image.