### PR TITLE
chore: Add OWNERS file for debugging base

### DIFF
--- a/dockerfiles/bases/debugging/OWNERS
+++ b/dockerfiles/bases/debugging/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - overvenus
+  - qiffang
+
+reviewers:
+  - TopScrew


### PR DESCRIPTION
This pull request updates the `dockerfiles/bases/debugging/OWNERS` file to assign appropriate approvers and reviewers for ownership.

Ownership assignment:

* Added `overvenus` and `qiffang` as approvers, and `TopScrew` as reviewer in `dockerfiles/bases/debugging/OWNERS`.