### PR TITLE
fix(packages): update builder images to latest versions for multiple components

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -275,7 +275,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 8.4.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2024.10.8-51-g9b98efb-centos7-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2025.8.17-4-g6fd188d-centos7-go1.23
       - if: {{ semver.CheckConstraint ">= 7.4.0-0, < 8.4.0-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2024.10.8-12-gb9ffe36-centos7-go1.21
       - if: {{ semver.CheckConstraint ">= 7.0.0-0, < 7.4.0-0" .Release.version }}
@@ -421,7 +421,7 @@ components:
         - {{ .Release.version }}
     builders:
       - if: {{ semver.CheckConstraint ">= 8.4.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2024.10.8-51-g9b98efb-centos7-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2025.8.17-4-g6fd188d-centos7-go1.23
       - if: {{ semver.CheckConstraint ">= 7.4.0-0, < 8.4.0-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2024.10.8-12-gb9ffe36-centos7-go1.21
       - if: {{ semver.CheckConstraint ">= 7.0.0-0, < 7.4.0-0" .Release.version }}
@@ -544,7 +544,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 8.4.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/pd:v2024.10.8-51-g9b98efb-centos7-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/pd:v2025.8.10-8-g63921ca-centos7-go1.23
       - if: {{ semver.CheckConstraint ">= 7.4.0-0, < 8.4.0-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/pd:v2024.10.8-12-gb9ffe36-centos7-go1.21
       - if: {{ semver.CheckConstraint ">= 7.0.0-0, < 7.4.0-0" .Release.version }}
@@ -883,7 +883,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 8.4.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/tidb:v2024.10.8-129-ga6c42c5-centos7-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/tidb:v2025.8.10-8-g63921ca-centos7-go1.23
       - if: {{ semver.CheckConstraint ">= 7.4.0-0, < 8.4.0-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/tidb:v2024.10.8-12-gb9ffe36-centos7-go1.21
       - if: {{ semver.CheckConstraint ">= 7.0.0-0, < 7.4.0-0" .Release.version }}
@@ -1349,7 +1349,7 @@ components:
     builders:
       # BUG: tidb-tools has not release branches and all tags taged on master branch.
       - if: {{ eq "experiment" .Release.profile }}
-        image: ghcr.io/pingcap-qe/cd/builders/tidb:v2024.10.8-51-g7bd274e-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/tidb:v2025.8.17-13-ga5750d9-go1.23
       - if: {{ ne "experiment" .Release.profile }}
         image: ghcr.io/pingcap-qe/cd/builders/tidb:v2024.10.8-12-gb9ffe36-centos7-go1.21
     routers:
@@ -1397,7 +1397,7 @@ components:
     builders:
       # BUG: tidb-ctl has not release branches and all tags taged on master branch.
       - if: (eq "experiment" .Release.profile)
-        image: ghcr.io/pingcap-qe/cd/builders/tidb:v2024.10.8-129-ga6c42c5-centos7-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/tidb:v2025.8.10-8-g63921ca-centos7-go1.23
       - if: (ne "experiment" .Release.profile)
         image: ghcr.io/pingcap-qe/cd/builders/tidb:v2024.10.8-12-gb9ffe36-centos7-go1.21
     routers:
@@ -1523,7 +1523,7 @@ components:
         - {{ .Release.version }}
     builders:
       - if: {{ semver.CheckConstraint ">= 1.6.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/tidb-operator:v2024.10.8-51-g9b98efb-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/tidb-operator:v2025.8.17-13-ga5750d9-go1.23
       - if: {{ semver.CheckConstraint "< 1.6.0-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/tidb-operator:v2024.10.8-14-g52a7228-go1.21
     routers:
@@ -1669,7 +1669,7 @@ components:
         - {{ .Release.version }}
     builders:
       - if: {{ semver.CheckConstraint ">= 8.4.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/tidb-dashboard:v2024.10.8-51-g9b98efb-centos7-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/tidb-dashboard:v2025.8.10-8-g63921ca-centos7-go1.23
       - if: {{ semver.CheckConstraint ">= 6.5.0-0, < 8.4.0-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/tidb-dashboard:v2024.10.8-12-gb9ffe36-centos7-go1.21
     routers:
@@ -2132,7 +2132,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 8.4.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/tiflow:v2024.10.8-51-g9b98efb-centos7-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/tiflow:v2025.8.17-13-ga5750d9-centos7-go1.23
       - if: {{ semver.CheckConstraint ">= 7.4.0-0, < 8.4.0-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/tiflow:v2024.10.8-12-gb9ffe36-centos7-go1.21
       - if: {{ semver.CheckConstraint ">= 7.0.0-0, < 7.4.0-0" .Release.version }}
@@ -2559,7 +2559,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 9.0.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/ticdc:v2024.10.8-78-gf83d845-centos7-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/ticdc:v2025.8.17-13-ga5750d9-centos7-go1.23
     routers:
       - description: For range [v9.0.0, )
         if: {{ semver.CheckConstraint ">= 9.0.0-0" .Release.version }}
@@ -2872,7 +2872,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 1.3.0-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/tidb:v2024.10.8-129-ga6c42c5-centos7-go1.23
+        image: ghcr.io/pingcap-qe/cd/builders/tidb:v2025.8.10-8-g63921ca-centos7-go1.23
       - if: {{ semver.CheckConstraint ">= 0.1.2-0, < 1.3.0-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/tidb:v2024.10.8-12-gb9ffe36-centos7-go1.21
     routers:


### PR DESCRIPTION
This pull request updates the builder images for several components in the `packages/packages.yaml.tmpl` file. The main purpose is to use newer image versions for building binaries and related artifacts, ensuring the build process uses the latest available sources and tools for each component.

**Builder image version updates:**

* **Core components:**
  - Updated builder image for `tidb` to `v2025.8.10-8-g63921ca-centos7-go1.23` for builds targeting version constraints `>= 8.4.0-0` and `>= 1.3.0-0`, as well as for `tidb-ctl` and other experiment profiles. [[1]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L886-R886) [[2]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L1400-R1400) [[3]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L2875-R2875)
  - Updated builder image for `pd` to `v2025.8.10-8-g63921ca-centos7-go1.23` for builds targeting version constraints `>= 8.4.0-0`.
  - Updated builder image for `ng-monitoring` to `v2025.8.17-4-g6fd188d-centos7-go1.23` for builds targeting version constraints `>= 8.4.0-0`. [[1]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L278-R278) [[2]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7L424-R424)
  - Updated builder image for `tidb-dashboard` to `v2025.8.10-8-g63921ca-centos7-go1.23` for builds targeting version constraints `>= 8.4.0-0`.
  - Updated builder image for `tiflow` to `v2025.8.17-13-ga5750d9-centos7-go1.23` for builds targeting version constraints `>= 8.4.0-0`.
  - Updated builder image for `ticdc` to `v2025.8.17-13-ga5750d9-centos7-go1.23` for builds targeting version constraints `>= 9.0.0-0`.

* **Operator and experiment profiles:**
  - Updated builder image for `tidb-operator` to `v2025.8.17-13-ga5750d9-go1.23` for builds targeting version constraints `>= 1.6.0-0`.
  - Updated builder image for `tidb` used in experiment profiles to `v2025.8.17-13-ga5750d9-go1.23`.

These updates ensure that the build pipeline uses the latest images, which may include new features, security patches, and improved compatibility with the current codebase.