### PR TITLE
fix(dockerfiles): bump tiup to v1.16.3

### DIFF
--- a/dockerfiles/bases/debugging/Dockerfile
+++ b/dockerfiles/bases/debugging/Dockerfile
@@ -33,9 +33,9 @@ RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
 
 # install tools: tiup
 # renovate: datasource=github-release depName=pingcap/tiup
-ARG TIUP_VER=1.16.2
+ARG TIUP_VER=v1.16.3
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
-    wget -q -O - https://tiup-mirrors.pingcap.com/tiup-v${TIUP_VER}-${OS}-${ARCH}.tar.gz | tar -zxvf - -C /usr/local/bin && \
+    wget -q -O - https://tiup-mirrors.pingcap.com/tiup-${TIUP_VER}-${OS}-${ARCH}.tar.gz | tar -zxvf - -C /usr/local/bin && \
     chmod 755 /usr/local/bin/tiup && \
     mkdir -p "$HOME/.tiup/bin" && \
     tiup mirror set --reset

--- a/dockerfiles/cd/builders/tem/Dockerfile
+++ b/dockerfiles/cd/builders/tem/Dockerfile
@@ -52,11 +52,12 @@ ENV PATH /root/go/bin/:$PATH
 
 # install tools: tiup
 # renovate: datasource=github-release depName=pingcap/tiup
-ARG TIUP_VER=1.16.1
+ARG TIUP_VER=v1.16.3
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
-    wget -q -O - https://tiup-mirrors.pingcap.com/tiup-v${TIUP_VER}-${OS}-${ARCH}.tar.gz | tar -zxvf - -C /usr/local/bin && \
+    wget -q -O - https://tiup-mirrors.pingcap.com/tiup-${TIUP_VER}-${OS}-${ARCH}.tar.gz | tar -zxvf - -C /usr/local/bin && \
     chmod 755 /usr/local/bin/tiup && \
-    mkdir -p "$HOME/.tiup/bin"
+    mkdir -p "$HOME/.tiup/bin" && \
+    tiup mirror set --reset
 
 ########### stage: non-root-builder, used for development with non-root user.
 FROM builder AS non-root-builder

--- a/dockerfiles/cd/utils/release/Dockerfile
+++ b/dockerfiles/cd/utils/release/Dockerfile
@@ -36,11 +36,12 @@ RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
 
 # install tools: tiup
 # renovate: datasource=github-release depName=pingcap/tiup
-ARG TIUP_VER=1.16.1
+ARG TIUP_VER=v1.16.3
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
-    wget -q -O - https://tiup-mirrors.pingcap.com/tiup-v${TIUP_VER}-${OS}-${ARCH}.tar.gz | tar -zxvf - -C /usr/local/bin && \
+    wget -q -O - https://tiup-mirrors.pingcap.com/tiup-${TIUP_VER}-${OS}-${ARCH}.tar.gz | tar -zxvf - -C /usr/local/bin && \
     chmod 755 /usr/local/bin/tiup && \
-    mkdir -p "$HOME/.tiup/bin"
+    mkdir -p "$HOME/.tiup/bin" && \
+    tiup mirror set --reset
 
 # install tools: aws-cli
 RUN apk add --no-cache python3 aws-cli py3-pip  && \


### PR DESCRIPTION
This pull request updates the installation of the `tiup` tool in several Dockerfiles to use the latest version and corrects the download URL format. Additionally, it ensures the tiup mirror is reset after installation for consistency across environments.

**Tiup version update and installation improvements:**

* Updated the `TIUP_VER` argument from `1.16.1` or `1.16.2` to `v1.16.3` in `dockerfiles/bases/debugging/Dockerfile`, `dockerfiles/cd/builders/tem/Dockerfile`, and `dockerfiles/cd/utils/release/Dockerfile` to use the latest tiup release. [[1]](diffhunk://#diff-52ee37e81c49905de8921faf89f169801660afbb2f9ddef1d6c0eb3b278808c3L36-R38) [[2]](diffhunk://#diff-bc07a56311decb83e8d422e4fb0db0fd33da730d202f6dc06d029f44971ae191L55-R60) [[3]](diffhunk://#diff-5cbd88ab49628ca7ea97ce8761e581d89b92afeb36daa1079fe009b997f83422L39-R44)
* Fixed the tiup download URL by removing the redundant `-v` prefix and using the correct format for the tarball in all affected Dockerfiles. [[1]](diffhunk://#diff-52ee37e81c49905de8921faf89f169801660afbb2f9ddef1d6c0eb3b278808c3L36-R38) [[2]](diffhunk://#diff-bc07a56311decb83e8d422e4fb0db0fd33da730d202f6dc06d029f44971ae191L55-R60) [[3]](diffhunk://#diff-5cbd88ab49628ca7ea97ce8761e581d89b92afeb36daa1079fe009b997f83422L39-R44)
* Added the command `tiup mirror set --reset` after installation to ensure the tiup mirror is properly initialized in all environments. [[1]](diffhunk://#diff-52ee37e81c49905de8921faf89f169801660afbb2f9ddef1d6c0eb3b278808c3L36-R38) [[2]](diffhunk://#diff-bc07a56311decb83e8d422e4fb0db0fd33da730d202f6dc06d029f44971ae191L55-R60) [[3]](diffhunk://#diff-5cbd88ab49628ca7ea97ce8761e581d89b92afeb36daa1079fe009b997f83422L39-R44)