### PR TITLE
Revert "chore(deps): update ghcr.io/pingcap-qe/cd/builders/tici docker tag to v2025.9.7-2-gd70d6e9-centos7"

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2920,7 +2920,7 @@ components:
         - {{ .Release.version }}
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
-      - image: ghcr.io/pingcap-qe/cd/builders/tici:v2025.9.7-2-gd70d6e9-centos7
+      - image: ghcr.io/pingcap-qe/cd/builders/tici:v2025.8.24-2-g31db9b6-centos7
     routers:
       - description: currently in demo stage
         os: [linux, darwin]
@@ -2967,7 +2967,7 @@ components:
         - {{ .Release.version }}
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
-      - image: ghcr.io/pingcap-qe/cd/builders/tici:v2025.9.7-2-gd70d6e9-centos7
+      - image: ghcr.io/pingcap-qe/cd/builders/tici:v2025.7.13-4-g801199f-centos7
     routers:
       - description: currently in demo stage
         os: [linux]


### PR DESCRIPTION
Reverts PingCAP-QE/artifacts#748

there's bug ref #714