### PR TITLE
chore(packages): lower minimum version constraint for ticdc builder and router

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2143,8 +2143,8 @@ components:
         image: ghcr.io/pingcap-qe/cd/builders/tiflow:v20240325-103-g043adb3-go1.18
     routers:
       - description: |
-            For range [v9.0.0, ). Since v9.0.0 we build and publish cdc components from `pingcap/ticdc` repository.
-        if: {{ semver.CheckConstraint ">= v9.0.0-0" .Release.version }}
+            For range [v8.5.4, ). Since v8.5.4 we build and publish cdc components from `pingcap/ticdc` repository.
+        if: {{ semver.CheckConstraint ">= v8.5.4-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
         profile: [release]
@@ -2266,8 +2266,8 @@ components:
             dockerfile: deployments/engine/docker/Dockerfile
             build_args:
               - GOPROXY=http://goproxy.pingcap.net,https://goproxy.cn,direct
-      - description: For range [v6.5.0, v9.0.0)
-        if: {{ semver.CheckConstraint ">= 6.5.0-0, < v9.0.0-0" .Release.version }}
+      - description: For range [v6.5.0, v8.5.4)
+        if: {{ semver.CheckConstraint ">= 6.5.0-0, < v8.5.4-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
         profile: [release]


### PR DESCRIPTION
Starts from v8.5.4, the cdc component will release from `pingcap/ticdc` repo.

This pull request updates the version constraints for building and publishing CDC components and their associated builders in the `packages.yaml.tmpl` configuration file. The main change is lowering the version threshold from `v9.0.0` to `v8.5.4`, so that builds and publishing from the `pingcap/ticdc` repository now start from version `v8.5.4` instead of `v9.0.0`.

**Version constraint updates for CDC components and builders:**

* Updated the router description and version constraint for building and publishing CDC components from `pingcap/ticdc` to start at `v8.5.4` instead of `v9.0.0`.
* Adjusted the version range for previous builds to end at `< v8.5.4` instead of `< v9.0.0`.
* Lowered the version constraint for the CDC binary builder and router from `>= 9.0.0-0` to `>= 8.5.4-0`, ensuring that the new builder and publishing logic applies from `v8.5.4` onward.

