### PR TITLE
fix(dockerfiles/base/pingcap-base): fix busybox tool

### DIFF
--- a/dockerfiles/bases/pingcap-base/Dockerfile
+++ b/dockerfiles/bases/pingcap-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/rockylinux/rockylinux:9.5.20241118
-COPY --from=busybox:1.37.0 /bin/busybox /bin/busybox
-RUN _date=20240730 dnf upgrade -y && dnf clean all
+COPY --from=busybox:1.37.0-musl /bin/busybox /bin/busybox
+RUN _date=20251022 dnf upgrade -y && dnf clean all
 
 # Add user and group to support run it with non-root.
 ARG PINGCAP_UID=1000

--- a/dockerfiles/bases/skaffold.yaml
+++ b/dockerfiles/bases/skaffold.yaml
@@ -60,7 +60,7 @@ build:
         dockerfile: debugging/Dockerfile
   tagPolicy:
     customTemplate:
-      template: "v1.10.0"
+      template: "v1.10.1"
   local:
     useDockerCLI: true
     useBuildkit: true


### PR DESCRIPTION
It's need high `glibc` version than the OS provided.

**Build and Dockerfile updates:**

* Updated the `dockerfiles/bases/pingcap-base/Dockerfile` to use `busybox:1.37.0-musl` instead of the standard image, and changed the base image upgrade date to `20251022` for a more recent update.
* Bumped the debugging image version in `dockerfiles/bases/skaffold.yaml` from `v1.10.0` to `v1.10.1` for the local build process.


