### PR TITLE
feat(packages): add next-gen image sync rules for delivery ticdc and tiproxy

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -399,7 +399,7 @@ image_copy_rules:
         - gcr.io/pingcap-public/dbaas/ticdc
     - description: delivery next-gen images built from classic branches and tags
       tags_regex:
-        - ^release-[0-9]+[.][0-9]+-next-gen$ # classic naing release branches
+        - ^release-[0-9]+[.][0-9]+-next-gen$ # classic naming release branches
         - ^v[0-9]+[.][0-9]+[.][0-9]+(-release[.][0-9]+)?-next-gen$ # GA semver tags built from classic tags
       dest_repositories:
         - gcr.io/pingcap-public/dbaas/ticdc


### PR DESCRIPTION
- delivery tiproxy built with `classic` profile but on `nextgen` branches and tags.
- delivery ticdc built with `nextgen` profile but on `classic` branches and tags.