### PR TITLE
chore(packages): add release-X.Y tag regex

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -95,6 +95,11 @@ image_copy_rules:
     - <<: *sync_pre_community_to_enterprise_repo
       dest_repositories:
         - gcr.io/pingcap-public/dbaas/ticdc
+    - description: delivery classic release branch image tags
+      tags_regex:
+        - ^release-[0-9]+[.][0-9]+(-[0-9a-f]{7,10})?$
+      dest_repositories:
+        - gcr.io/pingcap-public/dbaas/ticdc
     - <<: *sync_pre_community_semver_sha
       dest_repositories:
         - gcr.io/pingcap-public/dbaas/ticdc


### PR DESCRIPTION
This pull request makes a small update to the `packages/delivery.yaml` configuration file. The change adds a new tag pattern to the list of recognized tag formats, specifically supporting tags like `release-X.Y`.

* Added a regex pattern to match `release-X.Y` style tags in the `tags_regex` section of `packages/delivery.yaml`.