### PR TITLE
fix(packages): remove gcr.io dbaas destinations in tidb-x image delivery rules

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -401,40 +401,32 @@ image_copy_rules:
   us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/ticdc/image:
     - <<: *sync_nextgen
       dest_repositories:
-        - gcr.io/pingcap-public/dbaas/ticdc
         - us.gcr.io/pingcap-public/tidbx/ticdc
   us-docker.pkg.dev/pingcap-testing-account/hub/tikv/pd/image:
     - <<: *sync_nextgen
       dest_repositories:
-        - gcr.io/pingcap-public/dbaas/pd
         - us.gcr.io/pingcap-public/tidbx/pd
   us-docker.pkg.dev/pingcap-testing-account/hub/tikv/tikv/image:
     - <<: *sync_nextgen
       dest_repositories:
-        - gcr.io/pingcap-public/dbaas/tikv
         - us.gcr.io/pingcap-public/tidbx/tikv
   us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/tidb/images/tidb-server:
     - <<: *sync_nextgen
       dest_repositories:
-        - gcr.io/pingcap-public/dbaas/tidb
         - us.gcr.io/pingcap-public/tidbx/tidb
   us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/tidb/images/br:
     - <<: *sync_nextgen
       dest_repositories:
-        - gcr.io/pingcap-public/dbaas/br
         - us.gcr.io/pingcap-public/tidbx/br
   us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/tidb/images/tidb-lightning:
     - <<: *sync_nextgen
       dest_repositories:
-        - gcr.io/pingcap-public/dbaas/tidb-lightning
         - us.gcr.io/pingcap-public/tidbx/tidb-lightning
   us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/tidb/images/dumpling:
     - <<: *sync_nextgen
       dest_repositories:
-        - gcr.io/pingcap-public/dbaas/dumpling
         - us.gcr.io/pingcap-public/tidbx/dumpling
   us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/tiflash/image:
     - <<: *sync_nextgen
       dest_repositories:
-        - gcr.io/pingcap-public/dbaas/tiflash
         - us.gcr.io/pingcap-public/tidbx/tiflash


### PR DESCRIPTION


just keep the private repositories: `us.gcr.io/pingcap-public/tidbx/*`.