### PR TITLE
feat(packages): add FTS feature branch publish rules to delivery config

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -470,6 +470,11 @@ tiup_publish_rules:
       dest_mirrors:
         - staging
       version_regex_replace: "$1"
+    - description: for FTS feature branches
+      tags_regex:
+        - ^(feature-fts)_(linux|darwin)_(amd64|arm64)$
+      dest_mirrors:
+        - staging
   ^hub-zot.pingcap.net/hub/.+/package$: *tiup_rules
   ^us-docker.pkg.dev/pingcap-testing-account/hub/.+/package$: *tiup_rules
   ^us-docker.pkg.dev/pingcap-testing-account/tidbx/.+/package$:


### PR DESCRIPTION
This pull request adds a new publishing rule for FTS feature branches in the `tiup_publish_rules` section of `packages/delivery.yaml`. This update ensures that packages with tags matching the FTS feature branch pattern are correctly published to the `staging` mirror.

* **Publishing rules update:**
  * Added a new rule to handle tags matching the FTS feature branch pattern (`^(feature-fts)_(linux|darwin)_(amd64|arm64)$`), ensuring these packages are published to the `staging` mirror.