### PR TITLE
refactor(pakcages): update sync_diff_inspector package source to tiflow

### DIFF
--- a/packages/offline-packages.yaml.tmpl
+++ b/packages/offline-packages.yaml.tmpl
@@ -184,8 +184,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
-                  path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  url: "{{ .Release.registry }}/pingcap/tiflow/package:master_{{.Release.os }}_{{ .Release.arch }}"
+                  path: "sync-diff-inspector-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
               - name: etcdctl	# New in v6.0.0
@@ -282,8 +282,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
-                  path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  url: "{{ .Release.registry }}/pingcap/tiflow/package:master_{{.Release.os }}_{{ .Release.arch }}"
+                  path: "sync-diff-inspector-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
               - name: etcdctl	# New in v6.0.0
@@ -379,8 +379,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
-                  path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  url: "{{ .Release.registry }}/pingcap/tiflow/package:master_{{.Release.os }}_{{ .Release.arch }}"
+                  path: "sync-diff-inspector-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
               - name: etcdctl	# New in v6.0.0
@@ -478,8 +478,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
-                  path: "tidb-tools-.*.tar.gz"
+                  url: "{{ .Release.registry }}/pingcap/tiflow/package:master_{{.Release.os }}_{{ .Release.arch }}"
+                  path: "sync-diff-inspector-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
               - name: etcdctl	# New in v6.0.0
@@ -583,8 +583,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
-                  path: "tidb-tools-.*.tar.gz"
+                  url: "{{ .Release.registry }}/pingcap/tiflow/package:master_{{.Release.os }}_{{ .Release.arch }}"
+                  path: "sync-diff-inspector-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
               - name: etcdctl	# New in v6.0.0
@@ -807,8 +807,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
-                  path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  url: "{{ .Release.registry }}/pingcap/tiflow/package:master_{{.Release.os }}_{{ .Release.arch }}"
+                  path: "sync-diff-inspector-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
               - name: etcdctl	# New in v6.0.0
@@ -940,8 +940,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
-                  path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  url: "{{ .Release.registry }}/pingcap/tiflow/package:master_{{.Release.os }}_{{ .Release.arch }}"
+                  path: "sync-diff-inspector-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
               - name: etcdctl	# New in v6.0.0
@@ -1073,8 +1073,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
-                  path: "tidb-tools-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+                  url: "{{ .Release.registry }}/pingcap/tiflow/package:master_{{.Release.os }}_{{ .Release.arch }}"
+                  path: "sync-diff-inspector-(.*-)?{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
               - name: etcdctl	# New in v6.0.0
@@ -1208,8 +1208,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
-                  path: "tidb-tools-.*.tar.gz"
+                  url: "{{ .Release.registry }}/pingcap/tiflow/package:master_{{.Release.os }}_{{ .Release.arch }}"
+                  path: "sync-diff-inspector-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
               - name: etcdctl	# New in v6.0.0
@@ -1349,8 +1349,8 @@ editions:
               - name: sync_diff_inspector # New in v6.0.0
                 src:
                   type: oci
-                  url: "{{ .Release.registry }}/pingcap/tidb-tools/package:master_{{.Release.os }}_{{ .Release.arch }}"
-                  path: "tidb-tools-.*.tar.gz"
+                  url: "{{ .Release.registry }}/pingcap/tiflow/package:master_{{.Release.os }}_{{ .Release.arch }}"
+                  path: "sync-diff-inspector-.*.tar.gz"
                   extract: true
                   extract_inner_path: sync_diff_inspector
               - name: etcdctl	# New in v6.0.0


### PR DESCRIPTION
As the v8.5.x version will live for long times, I suggest to update the fetching source of LTS versions to artifacts of `tiflow` for `sync_diff_inspector` binary for release version <=9.0.0 in offline-packages.