### PR TITLE
ci(renovate): stop updating release-6.5 and older Dockerfiles

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,6 +38,15 @@
       "groupName": null
     },
     {
+      "description": "Do not update Dockerfiles for release-6.5 and lower image paths",
+      "matchFileNames": [
+        "dockerfiles/bases/**/release-6.5.Dockerfile",
+        "dockerfiles/products/**/~6.5.12/**",
+        "dockerfiles/products/**/lt6.5.12/**"
+      ],
+      "enabled": false
+    },
+    {
       "matchUpdateTypes": [
         "major",
         "minor"


### PR DESCRIPTION
## Summary
- disable Renovate updates for `dockerfiles/bases/**/release-6.5.Dockerfile`
- disable Renovate updates for `dockerfiles/products/**/~6.5.12/**` and `dockerfiles/products/**/lt6.5.12/**`
- keep Renovate updates enabled for newer Dockerfile paths

This makes PR #834 out of policy once this config lands.

## Testing
- `jq empty .github/renovate.json`
- `git diff --check`

```release-note
none
```