### PR TITLE
feat(packages): add nextgen tiflow route and delivery

### DIFF
--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -486,6 +486,18 @@ image_copy_rules:
     - <<: *sync_nextgen
       dest_repositories:
         - us.gcr.io/pingcap-public/tidbx/ticdc
+  us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tiflow/images/dm:
+    - <<: *sync_nextgen
+      dest_repositories:
+        - us.gcr.io/pingcap-public/tidbx/dm
+  us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tiflow/images/tiflow:
+    - <<: *sync_nextgen
+      dest_repositories:
+        - us.gcr.io/pingcap-public/tidbx/tiflow
+  us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tiflow/images/sync-diff-inspector:
+    - <<: *sync_nextgen
+      dest_repositories:
+        - us.gcr.io/pingcap-public/tidbx/sync-diff-inspector
   us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:
     - <<: *sync_nextgen
       dest_repositories:

--- a/packages/delivery.yaml
+++ b/packages/delivery.yaml
@@ -490,14 +490,6 @@ image_copy_rules:
     - <<: *sync_nextgen
       dest_repositories:
         - us.gcr.io/pingcap-public/tidbx/dm
-  us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tiflow/images/tiflow:
-    - <<: *sync_nextgen
-      dest_repositories:
-        - us.gcr.io/pingcap-public/tidbx/tiflow
-  us-docker.pkg.dev/pingcap-testing-account/tidbx/pingcap/tiflow/images/sync-diff-inspector:
-    - <<: *sync_nextgen
-      dest_repositories:
-        - us.gcr.io/pingcap-public/tidbx/sync-diff-inspector
   us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:
     - <<: *sync_nextgen
       dest_repositories:

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2244,7 +2244,7 @@ components:
         if: {{ semver.CheckConstraint ">= v9.0.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
-        profile: [release]
+        profile: [release, nextgen]
         steps:
           release:
             - os: darwin
@@ -2267,6 +2267,27 @@ components:
                 npm install -g yarn
             - script: |
                 make dm-master-with-webui dm-worker dmctl dm-syncer sync-diff-inspector
+          nextgen:
+            - os: darwin
+              description: install nodejs toolchain.
+              script: |
+                NODE_VERSION="v16.20.2"
+                NVM_VERSION="v0.39.5"
+                NVM_DIR="$HOME/.nvm"
+                mkdir -p $NVM_DIR
+
+                if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+                  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
+                fi
+                . $NVM_DIR/nvm.sh
+                nvm install ${NODE_VERSION}
+                nvm use ${NODE_VERSION}
+                nvm alias default ${NODE_VERSION}
+
+                node --version && npm --version
+                npm install -g yarn
+            - script: |
+                NEXT_GEN=1 make dm-master-with-webui dm-worker dmctl dm-syncer sync-diff-inspector
         artifacts:
           - name: "dm-master-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
             files:

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2287,7 +2287,7 @@ components:
                 node --version && npm --version
                 npm install -g yarn
             - script: |
-                NEXT_GEN=1 make dm-master-with-webui dm-worker dmctl dm-syncer sync-diff-inspector
+                NEXT_GEN=1 make dm-master-with-webui dm-worker dmctl dm-syncer
         artifacts:
           - name: "dm-master-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
             files:
@@ -2347,6 +2347,7 @@ components:
                 dmctl component of Data Migration Platform.
               entrypoint: dmctl/dmctl
           - name: "sync-diff-inspector-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            if: {{ ne "nextgen" .Release.profile }}
             files:
               - name: sync_diff_inspector
                 src:
@@ -2357,6 +2358,7 @@ components:
                 sync-diff-inspector is a tool used to verify the consistency across different MySQL-compatible data sources.
               entrypoint: sync_diff_inspector
           - name: container image - sync-diff-inspector
+            if: {{ ne "nextgen" .Release.profile }}
             type: image
             artifactory:
               repo: "{{ .Release.registry }}/pingcap/tiflow/images/sync-diff-inspector"
@@ -2381,6 +2383,7 @@ components:
                 src:
                   path: bin/dmctl
           - name: container image - tiflow-engine
+            if: {{ ne "nextgen" .Release.profile }}
             type: image
             artifactory:
               repo: "{{ .Release.registry }}/pingcap/tiflow/images/tiflow"

--- a/packages/scripts/get-delivery-target-images.ts
+++ b/packages/scripts/get-delivery-target-images.ts
@@ -35,6 +35,7 @@ function srcImages(
     "pingcap/tiflash/image",
     "pingcap/tiflow/images/cdc",
     "pingcap/tiflow/images/dm",
+    "pingcap/tiflow/images/sync-diff-inspector",
     "pingcap/tiflow/images/tiflow",
     "tikv/pd/image",
     "tikv/tikv/image",

--- a/packages/scripts/get-delivery-target-images.ts
+++ b/packages/scripts/get-delivery-target-images.ts
@@ -35,7 +35,6 @@ function srcImages(
     "pingcap/tiflash/image",
     "pingcap/tiflow/images/cdc",
     "pingcap/tiflow/images/dm",
-    "pingcap/tiflow/images/sync-diff-inspector",
     "pingcap/tiflow/images/tiflow",
     "tikv/pd/image",
     "tikv/tikv/image",


### PR DESCRIPTION
## Summary
- add `nextgen` support to the latest `tiflow` package route and keep the darwin nodejs bootstrap in the new profile
- add nextgen delivery rules for `tiflow`, `dm`, and `sync-diff-inspector` images in the `tidbx` registry path
- include `sync-diff-inspector` in the delivery target image enumeration helper so local delivery validation matches the configured rules

Closes #956

## Verification
- pre-change: `gen-package-images-with-config.sh tiflow linux amd64 v9.0.0 nextgen ...` failed with `No package routes matched`
- pre-change: `get-delivery-target-images.ts --version=v26.3.1-nextgen --registry=us-docker.pkg.dev/pingcap-testing-account/tidbx` did not include `dm` / `tiflow` / `sync-diff-inspector` targets
- post-change: the same `gen-package-images-with-config.sh` command generates a script with `NEXT_GEN=1 make dm-master-with-webui dm-worker dmctl dm-syncer sync-diff-inspector` and `tidbx` image destinations for all three tiflow-family images
- post-change: the same delivery target generation now includes `us.gcr.io/pingcap-public/tidbx/dm:v26.3.1-nextgen`, `.../tiflow:v26.3.1-nextgen`, and `.../sync-diff-inspector:v26.3.1-nextgen`
- post-change: `release` generation still emits the classic `hub/pingcap/tiflow/images/{sync-diff-inspector,dm,tiflow}` destinations
