### PR TITLE
ci: add build-essential-java Dockerfile + PR build module

### DIFF
--- a/.github/workflows/pull-ci-runtime-images.yaml
+++ b/.github/workflows/pull-ci-runtime-images.yaml
@@ -43,6 +43,7 @@ jobs:
             jenkins-special:
               - 'dockerfiles/ci/jenkins/tikv/**'
               - 'dockerfiles/ci/jenkins/tiflash/**'
+              - 'dockerfiles/ci/jenkins/docker/**'
             tici:
               - 'dockerfiles/ci/tici/**'
             skaffold:
@@ -121,7 +122,7 @@ jobs:
 
     strategy:
       matrix:
-        module: [ci-jenkins-tiflash, ci-jenkins-tikv]
+        module: [ci-jenkins-tiflash, ci-jenkins-tikv, ci-jenkins-docker-build-essential-java]
         platform: [linux/amd64, linux/arm64]
     steps:
       - name: Checkout sources

--- a/dockerfiles/ci/base/Dockerfile
+++ b/dockerfiles/ci/base/Dockerfile
@@ -73,7 +73,7 @@ ENV PATH=$PATH:/opt/gradle-${GRADLE_VER}/bin
 
 #   -> apache-maven
 ARG MAVEN_VER=3.8.9
-RUN wget https://downloads.apache.org/maven/maven-3/${MAVEN_VER}/binaries/apache-maven-${MAVEN_VER}-bin.tar.gz && \
+RUN wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VER}/binaries/apache-maven-${MAVEN_VER}-bin.tar.gz && \
     tar -xf apache-maven-${MAVEN_VER}-bin.tar.gz -C /opt && \
     rm apache-maven-${MAVEN_VER}-bin.tar.gz
 ENV PATH=$PATH:/opt/apache-maven-${MAVEN_VER}/bin

--- a/dockerfiles/ci/jenkins/docker/Dockerfile
+++ b/dockerfiles/ci/jenkins/docker/Dockerfile
@@ -1,0 +1,14 @@
+# Base image dockerfile: ci/base/Dockerfile
+ARG BASE_IMG=ghcr.io/pingcap-qe/ci/base:v2026.3.29-14-g90ae7ef-go1.25
+
+# renovate: datasource=docker depName=docker
+ARG DOCKER_CLI_IMG=docker:28.4.0-cli
+
+FROM ${DOCKER_CLI_IMG} AS dockercli
+FROM ${BASE_IMG}
+
+COPY --from=dockercli /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=dockercli /usr/local/libexec/docker/cli-plugins /usr/local/libexec/docker/cli-plugins
+
+RUN ln -sf /usr/local/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose && \
+    ln -sf /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/bin/docker-buildx

--- a/dockerfiles/ci/skaffold.yaml
+++ b/dockerfiles/ci/skaffold.yaml
@@ -93,3 +93,22 @@ build:
     useBuildkit: true
     concurrency: 0
     tryImportMissing: true
+---
+apiVersion: skaffold/v4beta6
+kind: Config
+metadata:
+  name: ci-jenkins-docker-build-essential-java
+build:
+  artifacts:
+    - image: docker
+      platforms: [linux/amd64, linux/arm64]
+      docker:
+        dockerfile: jenkins/docker/Dockerfile
+  tagPolicy:
+    customTemplate:
+      template: "build-essential-java-{{ .GIT }}"
+  local:
+    useDockerCLI: true
+    useBuildkit: true
+    concurrency: 0
+    tryImportMissing: true


### PR DESCRIPTION
Implements PR1 for build-essential-java.

- Add Dockerfile at dockerfiles/ci/jenkins/docker/Dockerfile (based on ci/base + docker cli/plugins)
- Add skaffold module ci-jenkins-docker-build-essential-java
- Extend pull-ci-runtime-images workflow to build the new module on PRs

Multica: FLA-118