### PR TITLE
feat(ci): add docs PDF runtime image

### DIFF
--- a/.github/workflows/pull-ci-runtime-images.yaml
+++ b/.github/workflows/pull-ci-runtime-images.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - "dockerfiles/ci/base/**/Dockerfile"
       - "dockerfiles/ci/base/**/*.Dockerfile"
+      - "dockerfiles/ci/docs-merged-update/**"
       - "dockerfiles/ci/jenkins/**/Dockerfile"
       - "dockerfiles/ci/jenkins/**/*.Dockerfile"
       - "dockerfiles/ci/tici/**/Dockerfile"
@@ -24,6 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       base-jenkins: ${{ steps.filter.outputs.base-jenkins }}
+      docs-merged-update: ${{ steps.filter.outputs.docs-merged-update }}
       jenkins-special: ${{ steps.filter.outputs.jenkins-special }}
       tici: ${{ steps.filter.outputs.tici }}
       skaffold: ${{ steps.filter.outputs.skaffold }}
@@ -40,6 +42,8 @@ jobs:
               - 'dockerfiles/ci/base/**/Dockerfile'
               - 'dockerfiles/ci/base/**/*.Dockerfile'
               - 'dockerfiles/ci/jenkins/Dockerfile'
+            docs-merged-update:
+              - 'dockerfiles/ci/docs-merged-update/**'
             jenkins-special:
               - 'dockerfiles/ci/jenkins/tikv/**'
               - 'dockerfiles/ci/jenkins/tiflash/**'
@@ -198,6 +202,65 @@ jobs:
         uses: heypigeonhq/setup-skaffold@3b1a0687de1b580d3879bf6b9d423255c9954587
         with:
           version: 2.15.0
+
+      - name: Build images
+        working-directory: dockerfiles/ci
+        run: |
+          skaffold build \
+            --build-concurrency=1 \
+            --cache-artifacts \
+            --default-repo=ghcr.io/pingcap-qe/ci \
+            --module=${{ matrix.module }} \
+            --platform=${{ matrix.platform }} \
+            --push=false
+
+  skaffold-docs-merged-update:
+    name: build docs merged-update runtime with skaffold
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.docs-merged-update == 'true' || needs.detect-changes.outputs.skaffold == 'true' }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        module: [ci-docs-merged-update]
+        platform: [linux/amd64, linux/arm64]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: "0"
+          fetch-tags: "true"
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup skaffold
+        uses: heypigeonhq/setup-skaffold@3b1a0687de1b580d3879bf6b9d423255c9954587
+        with:
+          version: 2.16.0
+
+      - name: Cache layers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: "~/.skaffold/cache"
+          key: skaffold/${{ matrix.platform }}/ci/${{ matrix.module }}-${{ github.sha }}
+          restore-keys: |
+            skaffold/${{ matrix.platform }}/ci/${{ matrix.module }}-
+            skaffold/${{ matrix.platform }}/ci/
 
       - name: Build images
         working-directory: dockerfiles/ci

--- a/.github/workflows/pull-ci-runtime-images.yaml
+++ b/.github/workflows/pull-ci-runtime-images.yaml
@@ -6,7 +6,7 @@ on:
     paths:
       - "dockerfiles/ci/base/**/Dockerfile"
       - "dockerfiles/ci/base/**/*.Dockerfile"
-      - "dockerfiles/ci/docs-merged-update/**"
+      - "dockerfiles/ci/docs-pdf-runtime/**"
       - "dockerfiles/ci/jenkins/**/Dockerfile"
       - "dockerfiles/ci/jenkins/**/*.Dockerfile"
       - "dockerfiles/ci/tici/**/Dockerfile"
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       base-jenkins: ${{ steps.filter.outputs.base-jenkins }}
-      docs-merged-update: ${{ steps.filter.outputs.docs-merged-update }}
+      docs-pdf-runtime: ${{ steps.filter.outputs.docs-pdf-runtime }}
       jenkins-special: ${{ steps.filter.outputs.jenkins-special }}
       tici: ${{ steps.filter.outputs.tici }}
       skaffold: ${{ steps.filter.outputs.skaffold }}
@@ -42,8 +42,8 @@ jobs:
               - 'dockerfiles/ci/base/**/Dockerfile'
               - 'dockerfiles/ci/base/**/*.Dockerfile'
               - 'dockerfiles/ci/jenkins/Dockerfile'
-            docs-merged-update:
-              - 'dockerfiles/ci/docs-merged-update/**'
+            docs-pdf-runtime:
+              - 'dockerfiles/ci/docs-pdf-runtime/**'
             jenkins-special:
               - 'dockerfiles/ci/jenkins/tikv/**'
               - 'dockerfiles/ci/jenkins/tiflash/**'
@@ -214,11 +214,11 @@ jobs:
             --platform=${{ matrix.platform }} \
             --push=false
 
-  skaffold-docs-merged-update:
-    name: build docs merged-update runtime with skaffold
+  skaffold-docs-pdf-runtime:
+    name: build docs PDF runtime with skaffold
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.docs-merged-update == 'true' || needs.detect-changes.outputs.skaffold == 'true' }}
+    if: ${{ needs.detect-changes.outputs.docs-pdf-runtime == 'true' || needs.detect-changes.outputs.skaffold == 'true' }}
 
     permissions:
       contents: read
@@ -226,7 +226,7 @@ jobs:
 
     strategy:
       matrix:
-        module: [ci-docs-merged-update]
+        module: [ci-docs-pdf-runtime]
         platform: [linux/amd64, linux/arm64]
 
     steps:

--- a/.github/workflows/release-ci-runtime-images.yaml
+++ b/.github/workflows/release-ci-runtime-images.yaml
@@ -7,7 +7,7 @@ on:
     paths:
       - "dockerfiles/ci/base/**/Dockerfile"
       - "dockerfiles/ci/base/**/*.Dockerfile"
-      - "dockerfiles/ci/docs-merged-update/**"
+      - "dockerfiles/ci/docs-pdf-runtime/**"
       - "dockerfiles/ci/jenkins/**/Dockerfile"
       - "dockerfiles/ci/jenkins/**/*.Dockerfile"
       - "dockerfiles/ci/tici/**/Dockerfile"
@@ -24,7 +24,7 @@ jobs:
     if: github.event_name == 'push'
     outputs:
       base-jenkins: ${{ steps.filter.outputs.base-jenkins }}
-      docs-merged-update: ${{ steps.filter.outputs.docs-merged-update }}
+      docs-pdf-runtime: ${{ steps.filter.outputs.docs-pdf-runtime }}
       jenkins-special: ${{ steps.filter.outputs.jenkins-special }}
       tici: ${{ steps.filter.outputs.tici }}
       skaffold: ${{ steps.filter.outputs.skaffold }}
@@ -41,8 +41,8 @@ jobs:
               - 'dockerfiles/ci/base/**/Dockerfile'
               - 'dockerfiles/ci/base/**/*.Dockerfile'
               - 'dockerfiles/ci/jenkins/Dockerfile'
-            docs-merged-update:
-              - 'dockerfiles/ci/docs-merged-update/**'
+            docs-pdf-runtime:
+              - 'dockerfiles/ci/docs-pdf-runtime/**'
             jenkins-special:
               - 'dockerfiles/ci/jenkins/tikv/**'
               - 'dockerfiles/ci/jenkins/tiflash/**'
@@ -224,14 +224,14 @@ jobs:
             --default-repo ghcr.io/pingcap-qe/ci \
             --module ${{ matrix.module }}
 
-  skaffold-docs-merged-update:
-    name: publish docs merged-update runtime with skaffold
+  skaffold-docs-pdf-runtime:
+    name: publish docs PDF runtime with skaffold
     runs-on: ubuntu-24.04
     needs: [detect-changes]
     if: |
       always() &&
       (github.event_name == 'workflow_dispatch' ||
-       needs.detect-changes.outputs.docs-merged-update == 'true' ||
+       needs.detect-changes.outputs.docs-pdf-runtime == 'true' ||
        needs.detect-changes.outputs.skaffold == 'true')
 
     permissions:
@@ -240,7 +240,7 @@ jobs:
 
     strategy:
       matrix:
-        module: [ci-docs-merged-update]
+        module: [ci-docs-pdf-runtime]
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/release-ci-runtime-images.yaml
+++ b/.github/workflows/release-ci-runtime-images.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - "dockerfiles/ci/base/**/Dockerfile"
       - "dockerfiles/ci/base/**/*.Dockerfile"
+      - "dockerfiles/ci/docs-merged-update/**"
       - "dockerfiles/ci/jenkins/**/Dockerfile"
       - "dockerfiles/ci/jenkins/**/*.Dockerfile"
       - "dockerfiles/ci/tici/**/Dockerfile"
@@ -23,6 +24,7 @@ jobs:
     if: github.event_name == 'push'
     outputs:
       base-jenkins: ${{ steps.filter.outputs.base-jenkins }}
+      docs-merged-update: ${{ steps.filter.outputs.docs-merged-update }}
       jenkins-special: ${{ steps.filter.outputs.jenkins-special }}
       tici: ${{ steps.filter.outputs.tici }}
       skaffold: ${{ steps.filter.outputs.skaffold }}
@@ -39,6 +41,8 @@ jobs:
               - 'dockerfiles/ci/base/**/Dockerfile'
               - 'dockerfiles/ci/base/**/*.Dockerfile'
               - 'dockerfiles/ci/jenkins/Dockerfile'
+            docs-merged-update:
+              - 'dockerfiles/ci/docs-merged-update/**'
             jenkins-special:
               - 'dockerfiles/ci/jenkins/tikv/**'
               - 'dockerfiles/ci/jenkins/tiflash/**'
@@ -210,6 +214,69 @@ jobs:
         uses: heypigeonhq/setup-skaffold@3b1a0687de1b580d3879bf6b9d423255c9954587
         with:
           version: 2.15.0
+
+      - name: Publish images
+        working-directory: dockerfiles/ci
+        run: |
+          skaffold build \
+            --build-concurrency 1 \
+            --cache-artifacts \
+            --default-repo ghcr.io/pingcap-qe/ci \
+            --module ${{ matrix.module }}
+
+  skaffold-docs-merged-update:
+    name: publish docs merged-update runtime with skaffold
+    runs-on: ubuntu-24.04
+    needs: [detect-changes]
+    if: |
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+       needs.detect-changes.outputs.docs-merged-update == 'true' ||
+       needs.detect-changes.outputs.skaffold == 'true')
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        module: [ci-docs-merged-update]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: "0"
+          fetch-tags: "true"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup skaffold
+        uses: heypigeonhq/setup-skaffold@3b1a0687de1b580d3879bf6b9d423255c9954587
+        with:
+          version: 2.16.0
+
+      - name: Cache layers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: "~/.skaffold/cache"
+          key: skaffold/ci/${{ matrix.module }}-${{ github.sha }}
+          restore-keys: |
+            skaffold/ci/${{ matrix.module }}-
+            skaffold/ci/
 
       - name: Publish images
         working-directory: dockerfiles/ci

--- a/dockerfiles/ci/docs-merged-update/Dockerfile
+++ b/dockerfiles/ci/docs-merged-update/Dockerfile
@@ -1,0 +1,16 @@
+FROM pandoc/extra@sha256:07f33f3c77fdde0eede08e2e145de82a048f35ff3e642546cb6e85da9b414498
+
+LABEL org.opencontainers.image.authors="wuhui.zuo@pingcap.com"
+LABEL org.opencontainers.image.description="Docs merged-update runtime with pandoc, xelatex, rclone, and WenQuanYi fonts"
+LABEL org.opencontainers.image.source="https://github.com/PingCAP-QE/artifacts"
+
+COPY --from=rclone/rclone@sha256:d5971950c2b370fb04dd3292541b5bda6d9103143fd7e345aeb435a399388afc /usr/local/bin/rclone /usr/local/bin/rclone
+
+RUN set -eux; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates fonts-wqy-microhei; \
+    rm -rf /var/lib/apt/lists/*; \
+    fc-cache -fv >/dev/null || true
+
+ENTRYPOINT ["/bin/bash", "-lc"]

--- a/dockerfiles/ci/docs-pdf-runtime/Dockerfile
+++ b/dockerfiles/ci/docs-pdf-runtime/Dockerfile
@@ -1,7 +1,7 @@
 FROM pandoc/extra@sha256:07f33f3c77fdde0eede08e2e145de82a048f35ff3e642546cb6e85da9b414498
 
 LABEL org.opencontainers.image.authors="wuhui.zuo@pingcap.com"
-LABEL org.opencontainers.image.description="Docs merged-update runtime with pandoc, xelatex, rclone, and WenQuanYi fonts"
+LABEL org.opencontainers.image.description="Docs PDF runtime with pandoc, xelatex, rclone, and WenQuanYi fonts"
 LABEL org.opencontainers.image.source="https://github.com/PingCAP-QE/artifacts"
 
 COPY --from=rclone/rclone@sha256:d5971950c2b370fb04dd3292541b5bda6d9103143fd7e345aeb435a399388afc /usr/local/bin/rclone /usr/local/bin/rclone

--- a/dockerfiles/ci/skaffold.yaml
+++ b/dockerfiles/ci/skaffold.yaml
@@ -78,13 +78,13 @@ build:
 apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
-  name: ci-docs-merged-update
+  name: ci-docs-pdf-runtime
 build:
   artifacts:
-    - image: docs-merged-update-runtime
+    - image: docs-pdf-runtime
       platforms: [linux/amd64, linux/arm64]
       docker:
-        dockerfile: docs-merged-update/Dockerfile
+        dockerfile: docs-pdf-runtime/Dockerfile
   tagPolicy:
     customTemplate:
       template: "{{ .GIT }}"

--- a/dockerfiles/ci/skaffold.yaml
+++ b/dockerfiles/ci/skaffold.yaml
@@ -78,6 +78,25 @@ build:
 apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
+  name: ci-docs-merged-update
+build:
+  artifacts:
+    - image: docs-merged-update-runtime
+      platforms: [linux/amd64, linux/arm64]
+      docker:
+        dockerfile: docs-merged-update/Dockerfile
+  tagPolicy:
+    customTemplate:
+      template: "{{ .GIT }}"
+  local:
+    useDockerCLI: true
+    useBuildkit: true
+    concurrency: 0
+    tryImportMissing: true
+---
+apiVersion: skaffold/v4beta6
+kind: Config
+metadata:
   name: ci-jenkins-tiflash
 build:
   artifacts:


### PR DESCRIPTION
## Summary
- add a dedicated docs merged-update runtime image under `dockerfiles/ci/docs-merged-update`
- wire the image into skaffold as its own `ci-docs-merged-update` module
- extend the CI pull/release workflows so the docs runtime is built and published independently

## Validation
- YAML parse via Ruby for `dockerfiles/ci/skaffold.yaml`, `.github/workflows/pull-ci-runtime-images.yaml`, and `.github/workflows/release-ci-runtime-images.yaml`
- `docker build -t docs-merged-update:test -f dockerfiles/ci/docs-merged-update/Dockerfile dockerfiles/ci`
- `docker run --rm --entrypoint /bin/bash docs-merged-update:test -lc 'python3 --version; pandoc --version | head -n 1; xelatex --version | head -n 1; rclone version | head -n 1; fc-match "WenQuanYi Micro Hei"; fc-match "WenQuanYi Micro Hei Mono"'`

## Note
- local skaffold multi-arch validation is blocked here because this workstation does not have the `docker buildx` CLI component installed; GitHub Actions uses `setup-buildx-action` for the PR/release path
