### PR TITLE
feat(cd): add go-1.25 build profile for tikv builder

### DIFF
--- a/dockerfiles/cd/builders/tikv/skaffold.centos7.non-root.yaml
+++ b/dockerfiles/cd/builders/tikv/skaffold.centos7.non-root.yaml
@@ -22,6 +22,16 @@ build:
     customTemplate:
       template: "{{ .GIT }}-centos7-non-root"
 profiles:
+  - name: go-1.25
+    patches:
+      - op: replace
+        path: /build/tagPolicy/customTemplate/template
+        value: "{{ .GIT }}-centos7-non-root-go1.25"
+      - op: add
+        path: /build/artifacts/0/docker/buildArgs
+        value:
+          # renovate: datasource=docker depName=golang
+          GOLANG_VERSION: 1.25.10
   - name: devtoolset8
     patches:
       - op: replace

--- a/dockerfiles/cd/builders/tikv/skaffold.centos7.yaml
+++ b/dockerfiles/cd/builders/tikv/skaffold.centos7.yaml
@@ -22,6 +22,16 @@ build:
     customTemplate:
       template: "{{ .GIT }}-centos7"
 profiles:
+  - name: go-1.25
+    patches:
+      - op: replace
+        path: /build/tagPolicy/customTemplate/template
+        value: "{{ .GIT }}-centos7-go1.25"
+      - op: add
+        path: /build/artifacts/0/docker/buildArgs
+        value:
+          # renovate: datasource=docker depName=golang
+          GOLANG_VERSION: 1.25.10
   - name: devtoolset8
     patches:
       - op: replace

--- a/dockerfiles/cd/builders/tikv/skaffold.non-root.yaml
+++ b/dockerfiles/cd/builders/tikv/skaffold.non-root.yaml
@@ -21,6 +21,17 @@ build:
     useBuildkit: true
     concurrency: 0
     tryImportMissing: true
+profiles:
+  - name: go-1.25
+    patches:
+      - op: replace
+        path: /build/tagPolicy/customTemplate/template
+        value: "{{ .GIT }}-non-root-go1.25"
+      - op: add
+        path: /build/artifacts/0/docker/buildArgs
+        value:
+          # renovate: datasource=docker depName=golang
+          GOLANG_VERSION: 1.25.10
 ---
 apiVersion: skaffold/v4beta6
 kind: Config

--- a/dockerfiles/cd/builders/tikv/skaffold.yaml
+++ b/dockerfiles/cd/builders/tikv/skaffold.yaml
@@ -21,6 +21,17 @@ build:
     useBuildkit: true
     concurrency: 0
     tryImportMissing: true
+profiles:
+  - name: go-1.25
+    patches:
+      - op: replace
+        path: /build/tagPolicy/customTemplate/template
+        value: "{{ .GIT }}-go1.25"
+      - op: add
+        path: /build/artifacts/0/docker/buildArgs
+        value:
+          # renovate: datasource=docker depName=golang
+          GOLANG_VERSION: 1.25.10
 ---
 apiVersion: skaffold/v4beta6
 kind: Config


### PR DESCRIPTION
## Summary
- add a `go-1.25` profile to the RockyLinux 8 tikv builder skaffold configs
- add a `go-1.25` profile to the CentOS 7 tikv builder skaffold configs
- keep the profile scoped to the primary `builder` config and leave `builder-fips` unchanged

## Notes
- the CentOS 7 tikv Dockerfile currently does not consume `GOLANG_VERSION`; this change adds the requested skaffold profile/tag wiring without changing that Dockerfile

Ref: FLA-161