### PR TITLE
fix(cd): wire go version into tikv centos7 builder

### DIFF
--- a/dockerfiles/cd/builders/tikv/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tikv/centos7/Dockerfile
@@ -28,6 +28,14 @@ RUN --mount=type=cache,target=/var/cache/yum \
     ln -s /usr/bin/cmake3 /usr/bin/cmake
 ENV DEVTOOLSET_VER=${DEVTOOLSET_VER}
 
+# install golang toolchain
+# renovate: datasource=docker depName=golang
+ARG GOLANG_VERSION=1.26.1
+RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
+    curl -fsSL https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz | tar -C /usr/local -xz
+ENV PATH=/usr/local/go/bin/:$PATH
+LABEL go-version="${GOLANG_VERSION}"
+
 # install protoc.
 # renovate: datasource=github-release depName=protocolbuffers/protobuf
 ARG PROTOBUF_VER=v3.15.8


### PR DESCRIPTION
## Summary
- add `ARG GOLANG_VERSION` to the TiKV CentOS7 builder Dockerfile
- install the Go toolchain from `dl.google.com` and expose it on `PATH`
- make the merged `go-1.25` / `non-root-go1.25` CentOS7 skaffold profiles change real image contents

## Context
Follow-up to #977, which merged the CentOS7 skaffold profiles without the matching Dockerfile wiring.