### PR TITLE
fix(cd): update tikv builder go version to 1.25.10

### DIFF
--- a/dockerfiles/cd/builders/tikv/Dockerfile
+++ b/dockerfiles/cd/builders/tikv/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 
 # install golang toolchain
 # renovate: datasource=docker depName=golang
-ARG GOLANG_VERSION=1.26.1
+ARG GOLANG_VERSION=1.25.10
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
     curl -fsSL https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz | tar -C /usr/local -xz
 ENV PATH=/usr/local/go/bin/:$PATH

--- a/dockerfiles/cd/builders/tikv/fips.Dockerfile
+++ b/dockerfiles/cd/builders/tikv/fips.Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 
 # install golang toolchain
 # renovate: datasource=docker depName=golang
-ARG GOLANG_VERSION=1.26.1
+ARG GOLANG_VERSION=1.25.10
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
     curl -fsSL https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz | tar -C /usr/local -xz
 ENV PATH=/usr/local/go/bin/:$PATH


### PR DESCRIPTION
## Summary
- downgrade the RockyLinux tikv builder Dockerfile Go toolchain from 1.26.1 to 1.25.10
- apply the same Go version change to the tikv FIPS builder Dockerfile
- leave skaffold configs unchanged as requested

## Testing
- not run (Dockerfile ARG-only change)