### PR TITLE
feat(packages): add tiflash experiment profile and image

### DIFF
--- a/dockerfiles/products/tiflash/experiment.Dockerfile
+++ b/dockerfiles/products/tiflash/experiment.Dockerfile
@@ -1,0 +1,50 @@
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.2
+FROM $BASE_IMG
+ENV LD_LIBRARY_PATH=/tiflash
+COPY --chmod=755 tiflash /tiflash
+
+
+# Wrapper at /tiflash/tiflash to keep compatibility with legacy TiFlash deployments
+# that hardcode this path. Actual binaries live under
+# /tiflash/binaries/{tiflash,tiflash-columnar}/tiflash.
+RUN if [ ! -e /tiflash/tiflash ]; then cat > /tiflash/tiflash <<'EOF' && chmod 755 /tiflash/tiflash; fi
+#!/usr/bin/env bash
+# Copyright 2026 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+TIFLASH_DIR=/tiflash/binaries/tiflash
+TIFLASH_COLUMNAR_DIR=/tiflash/binaries/tiflash-columnar
+
+# TIFLASH_COLUMNAR unset or "false" -> classic tiflash under /tiflash/binaries/tiflash.
+# "true" -> columnar build under /tiflash/binaries/tiflash-columnar when the binary exists.
+tiflash_columnar="${TIFLASH_COLUMNAR:-false}"
+tiflash_columnar_lower="$(echo "${tiflash_columnar}" | tr '[:upper:]' '[:lower:]')"
+
+if [ "${tiflash_columnar_lower}" = "true" ] && [ -x "${TIFLASH_COLUMNAR_DIR}/tiflash" ]; then
+    export LD_LIBRARY_PATH="${TIFLASH_COLUMNAR_DIR}"
+    # exec replaces this shell; lines below are not run on success.
+    exec "${TIFLASH_COLUMNAR_DIR}/tiflash" "$@"
+fi
+
+# Reached only when columnar mode is off, or columnar binary is missing.
+export LD_LIBRARY_PATH="${TIFLASH_DIR}"
+exec "${TIFLASH_DIR}/tiflash" "$@"
+EOF
+
+# Enable jemalloc profiling, inactive by default.
+# See https://jemalloc.net/jemalloc.3.html for details.
+ENV MALLOC_CONF="prof:true,prof_active:false"
+ENTRYPOINT ["/tiflash/tiflash", "server"]

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1882,7 +1882,7 @@ components:
         if: {{ semver.CheckConstraint ">= 8.5.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
-        profile: [release, enterprise, failpoint, nextgen]
+        profile: [release, enterprise, failpoint, nextgen, experiment]
         steps:
           release:
             - os: linux
@@ -1917,7 +1917,6 @@ components:
                 cargo --version
                 export TIFLASH_EDITION=Enterprise
                 export ENABLE_NEXT_GEN=true
-
             - os: linux
               script: |
                 ./release-linux-llvm/scripts/build-release.sh
@@ -1930,8 +1929,31 @@ components:
                 release-darwin/tiflash/tiflash version | grep -E 'Enable Features.*next-gen'
                 mkdir outputs
                 mv release-darwin/tiflash outputs/tiflash
+          experiment:
+            - script: |
+                cargo --version
+                export TIFLASH_EDITION=Enterprise
+                export ENABLE_NEXT_GEN=true
+            - os: linux
+              script: |
+                ./release-linux-llvm/scripts/build-release.sh
+                release-linux-llvm/tiflash/tiflash version | grep -E 'Enable Features.*next-gen'
+                mkdir outputs
+
+                # Handle both legacy single-binary output and next-gen split-binary output.
+                if [ -d release-linux-llvm/tiflash ] && [ -d release-linux-llvm/tiflash-columnar ]; then
+                  # Next-gen build produces both row-store and columnar binaries.
+                  mkdir -p outputs/tiflash/binaries
+                  mv release-linux-llvm/tiflash outputs/tiflash/binaries/tiflash
+                  mv release-linux-llvm/tiflash-columnar outputs/tiflash/binaries/tiflash-columnar
+                else
+                  # Legacy build produces only the tiflash directory.
+                  mv release-linux-llvm/tiflash outputs/tiflash
+                fi
+
         artifacts:
           - name: "tiflash-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
+            if: {{ ne "experiment" .Release.profile }}
             files: # output files.
               - name: tiflash/
                 src:
@@ -1941,6 +1963,7 @@ components:
               description: The TiFlash Columnar Storage Engine
               entrypoint: tiflash/tiflash
           - name: container image
+            if: {{ ne "experiment" .Release.profile }}
             type: image
             artifactory:
               repo: "{{ .Release.registry }}/pingcap/tiflash/image"
@@ -1949,6 +1972,17 @@ components:
               - name: tiflash/
                 src:
                   path: outputs/tiflash/
+          - name: container image
+            if: {{ eq "experiment" .Release.profile }}
+            type: image
+            artifactory:
+              repo: "{{ .Release.registry }}/pingcap/tiflash/image"
+            dockerfile: https://github.com/PingCAP-QE/artifacts/raw/main/dockerfiles/products/tiflash/experiment.Dockerfile
+            files:
+              - name: tiflash/
+                src:
+                  path: outputs/tiflash/
+
       - description: For v8.4.x
         if: {{ semver.CheckConstraint "~8.4.0-0" .Release.version }}
         os: [linux, darwin]


### PR DESCRIPTION
This pull request introduces support for an "experiment" build profile for TiFlash, enabling next-generation split-binary builds and providing a new Dockerfile and packaging logic for this profile. The changes ensure compatibility with both legacy and next-gen TiFlash deployments, and introduce a new container image build process for the "experiment" profile.

**Support for "experiment" build profile and next-gen TiFlash:**

* Added "experiment" to the list of available build profiles for TiFlash in `packages.yaml.tmpl`, enabling a new build and packaging workflow for experimental next-gen builds.
* Implemented experimental build steps that produce both row-store and columnar binaries when available, and handle legacy single-binary output for compatibility.

**Packaging and artifact changes:**

* Modified artifact and container image publishing logic to separate standard and experimental profiles: standard profiles exclude "experiment" artifacts and images, while the "experiment" profile uses a dedicated Dockerfile and artifact structure. [[1]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7R1966) [[2]](diffhunk://#diff-31ae6e632fba4bcb68649d473c355898c698ab9cf7946e4fc2189e6fbdf33fc7R1975-R1985)

**Dockerfile for experimental builds:**

* Added `dockerfiles/products/tiflash/experiment.Dockerfile`, which sets up the environment for next-gen TiFlash, provides a compatibility wrapper for legacy paths, and supports both classic and columnar binaries based on environment variables.

**Minor improvements:**

* Cleaned up and aligned build scripts for the new "experiment" profile to match the next-gen requirements.