### PR TITLE
fix(dockerfiles/cd): pin docs builder python to 3.6.15

### DIFF
--- a/.github/workflows/pull-cd-builder-images.yaml
+++ b/.github/workflows/pull-cd-builder-images.yaml
@@ -105,6 +105,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
+          fetch-depth: "0"
+          fetch-tags: "true"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd

--- a/.github/workflows/release-cd-builder-images.yaml
+++ b/.github/workflows/release-cd-builder-images.yaml
@@ -293,6 +293,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
+          fetch-depth: "0"
+          fetch-tags: "true"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd

--- a/dockerfiles/cd/builders/docs/Dockerfile
+++ b/dockerfiles/cd/builders/docs/Dockerfile
@@ -7,7 +7,7 @@
 #   - docker build --platform=linux/amd64 --target test -t docs-builder-test -f dockerfiles/cd/builders/docs/Dockerfile .
 
 ########### stage: builder
-FROM python:3.6.2 AS builder
+FROM python:3.6.15 AS builder
 LABEL org.opencontainers.image.authors="wuhui.zuo@pingcap.com"
 LABEL org.opencontainers.image.description="builder for PingCAP docs PDF generation"
 LABEL org.opencontainers.image.source="https://github.com/PingCAP-QE/artifacts"

--- a/dockerfiles/cd/builders/docs/Dockerfile
+++ b/dockerfiles/cd/builders/docs/Dockerfile
@@ -16,15 +16,14 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-# Fix EOL of the jessie sources
+# Fix EOL of the bullseye sources
 RUN printf '%s\n' \
-      'deb [trusted=yes] http://archive.debian.org/debian jessie main' \
-      'deb [trusted=yes] http://archive.debian.org/debian-security jessie/updates main' \
+      'deb http://deb.debian.org/debian bullseye main' \
+      'deb http://deb.debian.org/debian-security bullseye-security main' \
+      'deb http://deb.debian.org/debian bullseye-updates main' \
       >/etc/apt/sources.list \
  && printf '%s\n' \
       'Acquire::Check-Valid-Until "false";' \
-      'Acquire::AllowInsecureRepositories "true";' \
-      'APT::Get::AllowUnauthenticated "true";' \
       >/etc/apt/apt.conf.d/99archive
 
 # Install tools for generating the PDF documents.
@@ -41,8 +40,7 @@ RUN apt-get update \
       texlive-xetex \
       texlive-latex-extra \
       texlive-lang-cjk \
-      etoolbox \
-      ttf-wqy-microhei \
+      fonts-wqy-microhei \
       unzip \
  && ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime \
  && (locale-gen C.UTF-8 || true) \


### PR DESCRIPTION
### Summary

- Pin the docs PDF builder Dockerfile to `python:3.6.15` (previously `python:3.6.2`) for reproducible builds.
- Enable `fetch-depth: "0"` and `fetch-tags: "true"` in the CI workflow checkout step so the docs builder has full git history and tag information available during the build.

### Changes

| File | Change |
|------|--------|
| `dockerfiles/cd/builders/docs/Dockerfile` | Update base image `python:3.6.2` → `python:3.6.15` |
| `.github/workflows/release-cd-builder-images.yaml` | Add `fetch-depth: "0"` and `fetch-tags: "true"` to the docs builder checkout step |