### PR TITLE
fix(dockerfiles/bases): refresh release-6.5 base image packages

### DIFF
--- a/dockerfiles/bases/ng-monitoring-base/release-6.5.Dockerfile
+++ b/dockerfiles/bases/ng-monitoring-base/release-6.5.Dockerfile
@@ -7,7 +7,7 @@ FROM pingcap/centos-stream:8 AS arm64
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo \
-    && _date=20240919 dnf upgrade -y && dnf clean all \
+    && _date=20260609 dnf upgrade -y && dnf clean all \
     && sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo

--- a/dockerfiles/bases/pd-base/release-6.5.Dockerfile
+++ b/dockerfiles/bases/pd-base/release-6.5.Dockerfile
@@ -8,7 +8,7 @@ FROM pingcap/centos-stream:8 AS arm64
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo \
-    && _date=20240919 dnf upgrade -y && dnf clean all \
+    && _date=20260609 dnf upgrade -y && dnf clean all \
     && sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo

--- a/dockerfiles/bases/skaffold.yaml
+++ b/dockerfiles/bases/skaffold.yaml
@@ -144,7 +144,7 @@ build:
             path: tools-base/release-6.5.Dockerfile
   tagPolicy:
     customTemplate:
-      template: "v1.0.1-old"
+      template: "v1.0.2-old"
   local:
     useDockerCLI: true
     useBuildkit: true

--- a/dockerfiles/bases/tidb-base/release-6.5.Dockerfile
+++ b/dockerfiles/bases/tidb-base/release-6.5.Dockerfile
@@ -8,7 +8,7 @@ FROM pingcap/centos-stream:8 AS arm64
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo \
-    && _date=20240919 dnf upgrade -y && dnf clean all \
+    && _date=20260609 dnf upgrade -y && dnf clean all \
     && sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo

--- a/dockerfiles/bases/tikv-base/release-6.5.Dockerfile
+++ b/dockerfiles/bases/tikv-base/release-6.5.Dockerfile
@@ -10,7 +10,7 @@ FROM pingcap/centos-stream:8 AS arm64
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo \
-    && _date=20240919 dnf upgrade -y && dnf clean all \
+    && _date=20260609 dnf upgrade -y && dnf clean all \
     && sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo

--- a/dockerfiles/bases/tools-base/release-6.5.Dockerfile
+++ b/dockerfiles/bases/tools-base/release-6.5.Dockerfile
@@ -8,7 +8,7 @@ FROM pingcap/centos-stream:8 AS arm64
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo \
-    && _date=20240919 dnf upgrade -y && dnf clean all \
+    && _date=20260609 dnf upgrade -y && dnf clean all \
     && sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo


### PR DESCRIPTION
Summary
Refresh the release-6-5 base image track so CI republishes the old base images with newer package security fixes.

Changes
- Bump the `_date` cache-buster in the release-6.5 Dockerfiles for `ng-monitoring-base`, `pd-base`, `tidb-base`, `tikv-base`, and `tools-base` from `20240919` to `20260609` to force `dnf upgrade -y` to run again.
- Advance the `release-6-5` skaffold tag template from `v1.0.1-old` to `v1.0.2-old` so the refreshed images publish under a new patch tag.

Testing
- `git diff --check`
- Did not run local skaffold or image builds; `skaffold` and `yq` are not installed in this environment.

Risk
- Low to moderate: this republishes the old base-image track with updated packages, so any behavior change should be limited to the refreshed OS package set and caught by CI image builds.

Closes FLA-182
