### PR TITLE
fix(dockerfiles): bump base image consumers to refreshed tags

### DIFF
--- a/dockerfiles/bases/skaffold.yaml
+++ b/dockerfiles/bases/skaffold.yaml
@@ -80,7 +80,7 @@ build:
         dockerfile: tikv-base/fips.Dockerfile
   tagPolicy:
     customTemplate:
-      template: "v1.11.2-fips"
+      template: "v1.11.3-fips"
   local:
     useDockerCLI: true
     useBuildkit: true

--- a/dockerfiles/bases/tikv-base/fips.Dockerfile
+++ b/dockerfiles/bases/tikv-base/fips.Dockerfile
@@ -1,4 +1,4 @@
-ARG PINGCAP_BASE=ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.2
+ARG PINGCAP_BASE=ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.3
 FROM $PINGCAP_BASE
 # wget is requested by operator
 RUN dnf install -y tzdata wget openssl && dnf clean all

--- a/dockerfiles/cd/builders/ng-monitoring/Dockerfile
+++ b/dockerfiles/cd/builders/ng-monitoring/Dockerfile
@@ -42,7 +42,7 @@ RUN GOPROXY=${GOPROXY} make default -C /ws
 RUN /ws/bin/ng-monitoring-server -V
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/ng-monitoring-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/ng-monitoring-base:v1.11.3
 COPY --from=building /ws/bin/ng-monitoring-server /ng-monitoring-server
 
 WORKDIR /

--- a/dockerfiles/cd/builders/ng-monitoring/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/ng-monitoring/centos7/Dockerfile
@@ -47,7 +47,7 @@ RUN GOPROXY=${GOPROXY} make default -C /ws
 RUN /ws/bin/ng-monitoring-server -V
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/ng-monitoring-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/ng-monitoring-base:v1.11.3
 
 COPY --from=building /ws/bin/ng-monitoring-server /ng-monitoring-server
 

--- a/dockerfiles/cd/builders/pd/Dockerfile
+++ b/dockerfiles/cd/builders/pd/Dockerfile
@@ -43,7 +43,7 @@ RUN /ws/bin/pd-ctl -V
 RUN /ws/bin/pd-recover -V
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/pd-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/pd-base:v1.11.3
 COPY --from=building /ws/bin/pd-server  /pd-server
 COPY --from=building /ws/bin/pd-ctl     /pd-ctl
 COPY --from=building /ws/bin/pd-recover /pd-recover

--- a/dockerfiles/cd/builders/pd/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/pd/centos7/Dockerfile
@@ -47,7 +47,7 @@ RUN /pd/bin/pd-ctl -V
 RUN /pd/bin/pd-recover -V
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/pd-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/pd-base:v1.11.3
 
 COPY --from=building /pd/bin/pd-server  /pd-server
 COPY --from=building /pd/bin/pd-ctl     /pd-ctl

--- a/dockerfiles/cd/builders/tem/Dockerfile
+++ b/dockerfiles/cd/builders/tem/Dockerfile
@@ -74,7 +74,7 @@ RUN make build -C /tem
 RUN /tem/bin/tem --version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.3
 COPY --from=building /tem/bin/tem /tem
 
 WORKDIR /

--- a/dockerfiles/cd/builders/ticdc/Dockerfile
+++ b/dockerfiles/cd/builders/ticdc/Dockerfile
@@ -44,7 +44,7 @@ RUN GOPROXY=${GOPROXY} make kafka_consumer pulsar_consumer storage_consumer -C /
 RUN /ws/bin/cdc version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 
 COPY --from=building /ws/bin/cdc /cdc
 EXPOSE 8300

--- a/dockerfiles/cd/builders/ticdc/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/ticdc/centos7/Dockerfile
@@ -52,7 +52,7 @@ RUN GOPROXY=${GOPROXY} make kafka_consumer pulsar_consumer storage_consumer -C /
 RUN /ws/bin/cdc version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 
 COPY --from=building /ws/bin/cdc /cdc
 EXPOSE 8300

--- a/dockerfiles/cd/builders/tici/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tici/centos7/Dockerfile
@@ -39,7 +39,7 @@ RUN CARGO_NET_GIT_FETCH_WITH_CLI=true make release -c /ws
 RUN mkdir -p /ws/output && mv /ws/target/release/tici-server /ws/output && /ws/output/tici-server --version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.3
 COPY --from=building /ws/output/tici-server /tici-server
 
 ENTRYPOINT ["/tici-server"]

--- a/dockerfiles/cd/builders/tidb-dashboard/Dockerfile
+++ b/dockerfiles/cd/builders/tidb-dashboard/Dockerfile
@@ -47,7 +47,7 @@ RUN GOPROXY=${GOPROXY} make package -C /ws
 RUN /ws/bin/tidb-dashboard --version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/pd-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/pd-base:v1.11.3
 
 COPY --from=building /ws/bin/tidb-dashboard /tidb-dashboard
 

--- a/dockerfiles/cd/builders/tidb-dashboard/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tidb-dashboard/centos7/Dockerfile
@@ -50,7 +50,7 @@ RUN GOPROXY=${GOPROXY} make package -C /ws
 RUN /ws/bin/tidb-dashboard --version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/pd-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/pd-base:v1.11.3
 
 COPY --from=building /ws/bin/tidb-dashboard /tidb-dashboard
 

--- a/dockerfiles/cd/builders/tidb-operator/Dockerfile
+++ b/dockerfiles/cd/builders/tidb-operator/Dockerfile
@@ -35,7 +35,7 @@ ARG GOPROXY
 RUN GOPROXY=${GOPROXY} make build -C /ws && mv /ws/images/tidb-operator/bin/$(arch) /ws/bin
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.3
 
 COPY --from=building /ws/bin/tidb-scheduler /usr/local/bin/tidb-scheduler
 COPY --from=building /ws/bin/tidb-discovery /usr/local/bin/tidb-discovery

--- a/dockerfiles/cd/builders/tidb/Dockerfile
+++ b/dockerfiles/cd/builders/tidb/Dockerfile
@@ -42,7 +42,7 @@ RUN GOPROXY=${GOPROXY} make server -C /ws
 RUN /ws/bin/tidb-server -V
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tidb-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/tidb-base:v1.11.3
 COPY --from=building /ws/bin/tidb-server /tidb-server
 
 WORKDIR /

--- a/dockerfiles/cd/builders/tidb/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tidb/centos7/Dockerfile
@@ -65,7 +65,7 @@ RUN GOPROXY=${GOPROXY} make server -C /tidb
 RUN /tidb/bin/tidb-server -V
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tidb-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/tidb-base:v1.11.3
 
 COPY --from=building /tidb/bin/tidb-server /tidb-server
 

--- a/dockerfiles/cd/builders/tiflash/Dockerfile
+++ b/dockerfiles/cd/builders/tiflash/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir /ws/output && mv /ws/release-linux-llvm/tiflash /ws/output/tiflash
 RUN /ws/output/tiflash/tiflash version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.3
 
 ENV LD_LIBRARY_PATH=/tiflash
 COPY --from=building /ws/output/tiflash /tiflash

--- a/dockerfiles/cd/builders/tiflash/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tiflash/centos7/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir /ws/output && mv /ws/release-linux-llvm/tiflash /ws/output/tiflash
 RUN /ws/output/tiflash/tiflash version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.3
 
 ENV LD_LIBRARY_PATH=/tiflash
 COPY --from=building /ws/output/tiflash /tiflash

--- a/dockerfiles/cd/builders/tiflow/Dockerfile
+++ b/dockerfiles/cd/builders/tiflow/Dockerfile
@@ -71,7 +71,7 @@ RUN /ws/bin/dm-syncer -V
 RUN /ws/bin/dmctl -V
 
 ########### stage: Final image - cdc
-FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.2 AS final-cdc
+FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.3 AS final-cdc
 COPY --from=building-cdc /ws/bin/cdc /cdc
 
 EXPOSE 8300
@@ -82,7 +82,7 @@ RUN /cdc version
 
 
 ########### stage: Final image - dm
-FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.2 AS final-dm
+FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.3 AS final-dm
 COPY --from=building-dm /ws/bin/dm-master /dm-master
 COPY --from=building-dm /ws/bin/dm-worker /dm-worker
 COPY --from=building-dm /ws/bin/dm-syncer /dm-syncer

--- a/dockerfiles/cd/builders/tiflow/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tiflow/centos7/Dockerfile
@@ -82,7 +82,7 @@ RUN /tiflow/bin/dm-syncer -V
 RUN /tiflow/bin/dmctl -V
 
 ########### stage: Final image - cdc
-FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.2 AS final-cdc
+FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.3 AS final-cdc
 
 COPY --from=building-cdc /tiflow/bin/cdc /cdc
 EXPOSE 8300
@@ -93,7 +93,7 @@ RUN /cdc version
 
 
 ########### stage: Final image - dm
-FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.2 AS final-dm
+FROM ghcr.io/pingcap-qe/bases/tools-base:v1.11.3 AS final-dm
 
 COPY --from=building-dm /tiflow/bin/dm-master /dm-master
 COPY --from=building-dm /tiflow/bin/dm-worker /dm-worker

--- a/dockerfiles/cd/builders/tikv/Dockerfile
+++ b/dockerfiles/cd/builders/tikv/Dockerfile
@@ -53,7 +53,7 @@ RUN --mount=type=cache,target=/tikv/target \
 RUN /tikv/bin/tikv-server --version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3
 
 ENV MALLOC_CONF="prof:true,prof_active:false"
 COPY --from=building /tikv/bin/tikv-server  /tikv-server

--- a/dockerfiles/cd/builders/tikv/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tikv/centos7/Dockerfile
@@ -57,7 +57,7 @@ RUN --mount=type=cache,target=/tikv/target \
 RUN /tikv/bin/tikv-server --version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2
+FROM ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3
 
 ENV MALLOC_CONF="prof:true,prof_active:false"
 COPY --from=building /tikv/bin/tikv-server  /tikv-server

--- a/dockerfiles/cd/builders/tikv/fips.Dockerfile
+++ b/dockerfiles/cd/builders/tikv/fips.Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,target=/tikv/target \
 RUN /ws/bin/tikv-server --version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3-fips
+FROM ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2-fips
 
 ENV MALLOC_CONF="prof:true,prof_active:false"
 COPY --from=building /ws/bin/tikv-server  /tikv-server

--- a/dockerfiles/cd/builders/tikv/fips.Dockerfile
+++ b/dockerfiles/cd/builders/tikv/fips.Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,target=/tikv/target \
 RUN /ws/bin/tikv-server --version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2-fips
+FROM ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3-fips
 
 ENV MALLOC_CONF="prof:true,prof_active:false"
 COPY --from=building /ws/bin/tikv-server  /tikv-server

--- a/dockerfiles/products/ng-monitoring/Dockerfile
+++ b/dockerfiles/products/ng-monitoring/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/ng-monitoring-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/ng-monitoring-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 ng-monitoring-server /ng-monitoring-server
 EXPOSE 12020

--- a/dockerfiles/products/ng-monitoring/lt6.5.12/Dockerfile
+++ b/dockerfiles/products/ng-monitoring/lt6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/ng-monitoring-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/ng-monitoring-base:v1.0.2-old
 FROM $BASE_IMG
 COPY ng-monitoring-server /ng-monitoring-server
 EXPOSE 12020

--- a/dockerfiles/products/ng-monitoring/~6.5.12/Dockerfile
+++ b/dockerfiles/products/ng-monitoring/~6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/ng-monitoring-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/ng-monitoring-base:v1.11.3
 FROM $BASE_IMG
 COPY ng-monitoring-server /ng-monitoring-server
 EXPOSE 12020

--- a/dockerfiles/products/pd/Dockerfile
+++ b/dockerfiles/products/pd/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 pd-server pd-ctl pd-recover /
 EXPOSE 2379 2380

--- a/dockerfiles/products/pd/lt6.5.12/Dockerfile
+++ b/dockerfiles/products/pd/lt6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.0.2-old
 FROM $BASE_IMG
 COPY pd-server /pd-server
 COPY pd-ctl /pd-ctl

--- a/dockerfiles/products/pd/~6.5.12/Dockerfile
+++ b/dockerfiles/products/pd/~6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.11.3
 FROM $BASE_IMG
 COPY pd-server /pd-server
 COPY pd-ctl /pd-ctl

--- a/dockerfiles/products/ticdc/Dockerfile
+++ b/dockerfiles/products/ticdc/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 cdc /cdc
 EXPOSE 8300

--- a/dockerfiles/products/ticdc/test-tools/kafka-consumer.Dockerfile
+++ b/dockerfiles/products/ticdc/test-tools/kafka-consumer.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 cdc_kafka_consumer /cdc_kafka_consumer
 

--- a/dockerfiles/products/ticdc/test-tools/pulsar-consumer.Dockerfile
+++ b/dockerfiles/products/ticdc/test-tools/pulsar-consumer.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 cdc_pulsar_consumer /cdc_pulsar_consumer
 

--- a/dockerfiles/products/ticdc/test-tools/storage-consumer.Dockerfile
+++ b/dockerfiles/products/ticdc/test-tools/storage-consumer.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 cdc_storage_consumer /cdc_storage_consumer
 

--- a/dockerfiles/products/tici/Dockerfile
+++ b/dockerfiles/products/tici/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 tici-server /
 

--- a/dockerfiles/products/tidb-binlog/Dockerfile
+++ b/dockerfiles/products/tidb-binlog/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY pump /pump
 COPY drainer /drainer

--- a/dockerfiles/products/tidb-binlog/lt6.5.12/Dockerfile
+++ b/dockerfiles/products/tidb-binlog/lt6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.0.2-old
 FROM $BASE_IMG
 COPY pump /pump
 COPY drainer /drainer

--- a/dockerfiles/products/tidb-binlog/~6.5.12/Dockerfile
+++ b/dockerfiles/products/tidb-binlog/~6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY pump /pump
 COPY drainer /drainer

--- a/dockerfiles/products/tidb-dashboard/Dockerfile
+++ b/dockerfiles/products/tidb-dashboard/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 tidb-dashboard /tidb-dashboard
 EXPOSE 12333

--- a/dockerfiles/products/tidb-dashboard/lt6.5.12/Dockerfile
+++ b/dockerfiles/products/tidb-dashboard/lt6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.0.2-old
 FROM $BASE_IMG
 COPY tidb-dashboard /tidb-dashboard
 EXPOSE 12333

--- a/dockerfiles/products/tidb-dashboard/~6.5.12/Dockerfile
+++ b/dockerfiles/products/tidb-dashboard/~6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pd-base:v1.11.3
 FROM $BASE_IMG
 COPY tidb-dashboard /tidb-dashboard
 EXPOSE 12333

--- a/dockerfiles/products/tidb-tools/Dockerfile
+++ b/dockerfiles/products/tidb-tools/Dockerfile
@@ -1,3 +1,3 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 sync_diff_inspector /sync_diff_inspector

--- a/dockerfiles/products/tidb-tools/lt6.5.12/Dockerfile
+++ b/dockerfiles/products/tidb-tools/lt6.5.12/Dockerfile
@@ -1,3 +1,3 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.0.2-old
 FROM $BASE_IMG
 COPY sync_diff_inspector /sync_diff_inspector

--- a/dockerfiles/products/tidb-tools/~6.5.12/Dockerfile
+++ b/dockerfiles/products/tidb-tools/~6.5.12/Dockerfile
@@ -1,3 +1,3 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY sync_diff_inspector /sync_diff_inspector

--- a/dockerfiles/products/tidb/br.Dockerfile
+++ b/dockerfiles/products/tidb/br.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 br /br
 CMD ["/br"]

--- a/dockerfiles/products/tidb/dumpling.Dockerfile
+++ b/dockerfiles/products/tidb/dumpling.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 dumpling /dumpling
 CMD ["/dumpling"]

--- a/dockerfiles/products/tidb/lt6.5.12/br.Dockerfile
+++ b/dockerfiles/products/tidb/lt6.5.12/br.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.0.2-old
 FROM $BASE_IMG
 
 COPY br /br

--- a/dockerfiles/products/tidb/lt6.5.12/dumpling.Dockerfile
+++ b/dockerfiles/products/tidb/lt6.5.12/dumpling.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.0.2-old
 FROM $BASE_IMG
 
 COPY dumpling /dumpling

--- a/dockerfiles/products/tidb/lt6.5.12/tidb-lightning.Dockerfile
+++ b/dockerfiles/products/tidb/lt6.5.12/tidb-lightning.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.0.2-old
 FROM $BASE_IMG
 
 COPY tidb-lightning /tidb-lightning

--- a/dockerfiles/products/tidb/lt6.5.12/tidb.Dockerfile
+++ b/dockerfiles/products/tidb/lt6.5.12/tidb.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.0.2-old
 FROM $BASE_IMG
 COPY tidb-server /tidb-server
 EXPOSE 4000

--- a/dockerfiles/products/tidb/lt6.5.12/tidb.enterprise.Dockerfile
+++ b/dockerfiles/products/tidb/lt6.5.12/tidb.enterprise.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.0.2-old
 FROM $BASE_IMG
 COPY tidb-server /tidb-server
 COPY audit-1.so /plugins/audit-1.so

--- a/dockerfiles/products/tidb/tidb-lightning.Dockerfile
+++ b/dockerfiles/products/tidb/tidb-lightning.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 tidb-lightning tidb-lightning-ctl /
 EXPOSE 8289

--- a/dockerfiles/products/tidb/tidb.Dockerfile
+++ b/dockerfiles/products/tidb/tidb.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 tidb-server /tidb-server
 EXPOSE 4000

--- a/dockerfiles/products/tidb/tidb.enterprise.Dockerfile
+++ b/dockerfiles/products/tidb/tidb.enterprise.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 tidb-server /tidb-server
 COPY --chmod=755 audit-1.so whitelist-1.so /plugins/

--- a/dockerfiles/products/tidb/~6.5.12/br.Dockerfile
+++ b/dockerfiles/products/tidb/~6.5.12/br.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 
 COPY br /br

--- a/dockerfiles/products/tidb/~6.5.12/dumpling.Dockerfile
+++ b/dockerfiles/products/tidb/~6.5.12/dumpling.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 
 COPY dumpling /dumpling

--- a/dockerfiles/products/tidb/~6.5.12/tidb-lightning.Dockerfile
+++ b/dockerfiles/products/tidb/~6.5.12/tidb-lightning.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 
 COPY tidb-lightning /tidb-lightning

--- a/dockerfiles/products/tidb/~6.5.12/tidb.Dockerfile
+++ b/dockerfiles/products/tidb/~6.5.12/tidb.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.11.3
 FROM $BASE_IMG
 COPY tidb-server /tidb-server
 EXPOSE 4000

--- a/dockerfiles/products/tidb/~6.5.12/tidb.enterprise.Dockerfile
+++ b/dockerfiles/products/tidb/~6.5.12/tidb.enterprise.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tidb-base:v1.11.3
 FROM $BASE_IMG
 COPY tidb-server /tidb-server
 COPY audit-1.so /plugins/audit-1.so

--- a/dockerfiles/products/tiflash/Dockerfile
+++ b/dockerfiles/products/tiflash/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.3
 FROM $BASE_IMG
 ENV LD_LIBRARY_PATH=/tiflash
 COPY --chmod=755 tiflash /tiflash

--- a/dockerfiles/products/tiflash/experiment.Dockerfile
+++ b/dockerfiles/products/tiflash/experiment.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.3
 FROM $BASE_IMG
 ENV LD_LIBRARY_PATH=/tiflash
 COPY --chmod=755 tiflash /tiflash

--- a/dockerfiles/products/tiflash/lt6.5.12/Dockerfile
+++ b/dockerfiles/products/tiflash/lt6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.0.2-old
 FROM $BASE_IMG
 ENV LD_LIBRARY_PATH=/tiflash
 COPY tiflash /tiflash

--- a/dockerfiles/products/tiflash/~6.5.12/Dockerfile
+++ b/dockerfiles/products/tiflash/~6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflash-base:v1.11.3
 FROM $BASE_IMG
 ENV LD_LIBRARY_PATH=/tiflash
 COPY tiflash /tiflash

--- a/dockerfiles/products/tiflow/dm.Dockerfile
+++ b/dockerfiles/products/tiflow/dm.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 dm-worker dm-master dmctl /
 EXPOSE 8291 8261 8262

--- a/dockerfiles/products/tiflow/lt6.5.12/dm.Dockerfile
+++ b/dockerfiles/products/tiflow/lt6.5.12/dm.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflow-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflow-base:v1.0.2-old
 FROM $BASE_IMG
 
 COPY dm-worker /dm-worker

--- a/dockerfiles/products/tiflow/lt6.5.12/ticdc.Dockerfile
+++ b/dockerfiles/products/tiflow/lt6.5.12/ticdc.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflow-base:v1.0.1-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tiflow-base:v1.0.2-old
 FROM $BASE_IMG
 
 COPY cdc /cdc

--- a/dockerfiles/products/tiflow/sync-diff-inspector.Dockerfile
+++ b/dockerfiles/products/tiflow/sync-diff-inspector.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 sync_diff_inspector /sync_diff_inspector
 CMD ["/sync_diff_inspector"]

--- a/dockerfiles/products/tiflow/ticdc.Dockerfile
+++ b/dockerfiles/products/tiflow/ticdc.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 cdc /cdc
 EXPOSE 8300

--- a/dockerfiles/products/tiflow/~6.5.12/dm.Dockerfile
+++ b/dockerfiles/products/tiflow/~6.5.12/dm.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 
 COPY dm-worker /dm-worker

--- a/dockerfiles/products/tiflow/~6.5.12/ticdc.Dockerfile
+++ b/dockerfiles/products/tiflow/~6.5.12/ticdc.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tools-base:v1.11.3
 FROM $BASE_IMG
 
 COPY cdc /cdc

--- a/dockerfiles/products/tikv/Dockerfile
+++ b/dockerfiles/products/tikv/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 tikv-server tikv-ctl /
 ENV MALLOC_CONF="prof:true,prof_active:false"

--- a/dockerfiles/products/tikv/fips.Dockerfile
+++ b/dockerfiles/products/tikv/fips.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3-fips
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2-fips
 FROM $BASE_IMG
 COPY --chmod=755 tikv-server tikv-ctl /
 ENV MALLOC_CONF="prof:true,prof_active:false"

--- a/dockerfiles/products/tikv/fips.Dockerfile
+++ b/dockerfiles/products/tikv/fips.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2-fips
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3-fips
 FROM $BASE_IMG
 COPY --chmod=755 tikv-server tikv-ctl /
 ENV MALLOC_CONF="prof:true,prof_active:false"

--- a/dockerfiles/products/tikv/lt6.5.12/Dockerfile
+++ b/dockerfiles/products/tikv/lt6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.0.0-old
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.0.2-old
 FROM $BASE_IMG
 COPY tikv-server /tikv-server
 COPY tikv-ctl /tikv-ctl

--- a/dockerfiles/products/tikv/next-gen.Dockerfile
+++ b/dockerfiles/products/tikv/next-gen.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=755 tikv-server cse-ctl tikv-worker /
 ENV MALLOC_CONF="prof:true,prof_active:false"

--- a/dockerfiles/products/tikv/~6.5.12/Dockerfile
+++ b/dockerfiles/products/tikv/~6.5.12/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3
 FROM $BASE_IMG
 COPY tikv-server /tikv-server
 COPY tikv-ctl /tikv-ctl

--- a/dockerfiles/products/tiproxy/Dockerfile
+++ b/dockerfiles/products/tiproxy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.2
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.3
 FROM $BASE_IMG
 COPY --chmod=0755 tiproxy tiproxyctl /bin/
 COPY --chmod=0644 conf/* /etc/proxy/


### PR DESCRIPTION
Summary
Update base image consumers to the refreshed base image tags produced by PR #994 and PR #996, and prepare the refreshed FIPS base tag for publish.

Changes
- Bump non-old `*-base:v1.11.2` builder/product consumers to `v1.11.3`
- Bump `dockerfiles/bases/skaffold.yaml` fips publish tag to `v1.11.3-fips`
- Keep downstream FIPS consumers on `tikv-base:v1.11.2-fips` until `v1.11.3-fips` exists in GHCR after this PR publishes it
- Bump `lt6.5.12` old-track product consumers from `v1.0.0-old` / `v1.0.1-old` to `v1.0.2-old`
- Keep the existing direct `pingcap-base:v1.11.3` updates from the first commit

Testing
- `git diff --check`
- Manual EOF/trailing-whitespace check for changed files
- `rg -n "v1\.11\.2(?!-fips)" dockerfiles -P`
- `rg -n "v1\.0\.[01]-old" dockerfiles/products dockerfiles/cd dockerfiles/bases`
- Note: local `pre-commit` command is unavailable in this workspace; PR CI/pre-commit.ci is running.

Risk
Low to moderate. This retargets existing Dockerfiles to already-refreshed base image tags; rollback is to revert this PR or restore the prior base tags. FIPS downstream consumers intentionally stay on the currently published FIPS tag to avoid GHCR manifest misses in PR CI.
