### PR TITLE
feat(packages): update tiflash nextgen image process

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -1890,7 +1890,7 @@ components:
         if: {{ semver.CheckConstraint ">= 8.5.0-0" .Release.version }}
         os: [linux, darwin]
         arch: [amd64, arm64]
-        profile: [release, enterprise, failpoint, nextgen, experiment]
+        profile: [release, enterprise, failpoint, nextgen]
         steps:
           release:
             - os: linux
@@ -1930,24 +1930,6 @@ components:
                 ./release-linux-llvm/scripts/build-release.sh
                 release-linux-llvm/tiflash/tiflash version | grep -E 'Enable Features.*next-gen'
                 mkdir outputs
-                mv release-linux-llvm/tiflash outputs/tiflash
-            - os: darwin
-              script: |
-                ./release-darwin/build/build-release.sh
-                release-darwin/tiflash/tiflash version | grep -E 'Enable Features.*next-gen'
-                mkdir outputs
-                mv release-darwin/tiflash outputs/tiflash
-          experiment:
-            - script: |
-                cargo --version
-                export TIFLASH_EDITION=Enterprise
-                export ENABLE_NEXT_GEN=true
-            - os: linux
-              script: |
-                ./release-linux-llvm/scripts/build-release.sh
-                release-linux-llvm/tiflash/tiflash version | grep -E 'Enable Features.*next-gen'
-                mkdir outputs
-
                 # Handle both legacy single-binary output and next-gen split-binary output.
                 if [ -d release-linux-llvm/tiflash ] && [ -d release-linux-llvm/tiflash-columnar ]; then
                   # Next-gen build produces both row-store and columnar binaries.
@@ -1958,6 +1940,12 @@ components:
                   # Legacy build produces only the tiflash directory.
                   mv release-linux-llvm/tiflash outputs/tiflash
                 fi
+            - os: darwin
+              script: |
+                ./release-darwin/build/build-release.sh
+                release-darwin/tiflash/tiflash version | grep -E 'Enable Features.*next-gen'
+                mkdir outputs
+                mv release-darwin/tiflash outputs/tiflash
 
         artifacts:
           - name: "tiflash-{{ .Release.version }}-{{ .Release.os }}-{{ .Release.arch }}.tar.gz"
@@ -1970,17 +1958,6 @@ components:
               description: The TiFlash Columnar Storage Engine
               entrypoint: tiflash/tiflash
           - name: container image
-            if: {{ ne "experiment" .Release.profile }}
-            type: image
-            artifactory:
-              repo: "{{ .Release.registry }}/pingcap/tiflash/image"
-            dockerfile: https://github.com/PingCAP-QE/artifacts/raw/main/dockerfiles/products/tiflash/Dockerfile
-            files:
-              - name: tiflash/
-                src:
-                  path: outputs/tiflash/
-          - name: container image
-            if: {{ eq "experiment" .Release.profile }}
             type: image
             artifactory:
               repo: "{{ .Release.registry }}/pingcap/tiflash/image"


### PR DESCRIPTION
## For branch release-nextgen-202603
```
/devbuild trigger --product=tiflash --version=v26.3.0-dev --engine=tekton --edition=experiment --gitRef=branch/release-nextgen-202603 --platform=linux
```
https://tibuild.pingcap.net/api/devbuilds/1500901

Built successfully:
* https://internal2-do.pingcap.net/tekton/#/namespaces/ee-cd/pipelineruns/bp-tiflash-experiment-linux-amd64-hxcqk?pipelineTask=checkout&step=clone
* https://internal2-do.pingcap.net/tekton/#/namespaces/ee-cd/pipelineruns/bp-tiflash-experiment-linux-arm64-6tswd?pipelineTask=checkout&step=clone

```
# Start without -e TIFLASH_COLUMNAR=true
> podman run --rm -it --entrypoint /tiflash/tiflash us-docker.pkg.dev/pingcap-testing-account/dev/pingcap/tiflash/image:release-nextgen-202603-experiment version

TiFlash
Release Version: v26.3.1-1-g441bc90f0
Edition:         Enterprise
Git Commit Hash: 441bc90f04756bb7ce7beeba75725aaae9098df8
Git Branch:      HEAD
UTC Build Time:  2026-06-10 05:29:27
Enable Features: jemalloc sm4(GmSSL) mem-profiling avx2 avx512 unwind thinlto next-gen hnsw.l2=skylake hnsw.cosine=skylake vec.l2=skylake vec.cos=skylake
Profile:         RELWITHDEBINFO
Compiler:        clang++ 17.0.6

Raft Proxy
Git Commit Hash:   5fa3872069ec9ee85a9faf633030a0ee9d090197
Git Commit Branch: HEAD
UTC Build Time:    ""
Rust Version:      rustc 1.77.0-nightly (89e2160c4 2023-12-27)
Storage Engine:    tiflash
Prometheus Prefix: tiflash_proxy_
Profile:           release
Enable Features:   "raftstore-proxy/external-jemalloc" portable sse test-engine-kv-rocksdb test-engine-raft-raft-engine cloud-aws cloud-gcp cloud-azure portable sse test-engine-kv-rocksdb test-engine-raft-raft-engine cloud-aws cloud-gcp cloud-azure

# Start with -e TIFLASH_COLUMNAR=true. It will run the /tiflash/binaries/tiflash-column/tiflash
# "Enable Features" include "columnar"
>  podman run --rm -it -e TIFLASH_COLUMNAR=true --entrypoint /tiflash/tiflash us-docker.pkg.dev/pingcap-testing-account/dev/pingcap/tiflash/image:release-nextgen-202603-experiment version

TiFlash
Release Version: v26.3.1-1-g441bc90f0
Edition:         Enterprise
Git Commit Hash: 441bc90f04756bb7ce7beeba75725aaae9098df8
Git Branch:      HEAD
UTC Build Time:  2026-06-10 04:42:33
Enable Features: jemalloc sm4(GmSSL) mem-profiling avx2 avx512 unwind thinlto next-gen columnar hnsw.l2=skylake hnsw.cosine=skylake vec.l2=skylake vec.cos=skylake
Profile:         RELWITHDEBINFO
Compiler:        clang++ 17.0.6

TiFlash Columnar Hub
Git Commit Hash:   Unknown
Rust Version:      rustc 1.87.0-nightly (96cfc7558 2025-02-27)
Profile:           release
```

## For branch release-nextgen-20251011
```
/devbuild trigger --product=tiflash --version=v25.11.0-dev --engine=tekton --edition=experiment --gitRef=branch/release-nextgen-20251011 --platform=linux
```
https://tibuild.pingcap.net/api/devbuilds/1500902

Built successfully:
* https://internal2-do.pingcap.net/tekton/#/namespaces/ee-cd/pipelineruns/bp-tiflash-experiment-linux-amd64-bp7mc?pipelineTask=checkout&step=clone
* https://internal2-do.pingcap.net/tekton/#/namespaces/ee-cd/pipelineruns/bp-tiflash-experiment-linux-arm64-nn79x?pipelineTask=checkout&step=clone
```
>  gcloud auth print-access-token | podman login -u oauth2accesstoken --password-stdin us-docker.pkg.dev         
# Start without -e TIFLASH_COLUMNAR=true
>  podman run --rm -it --entrypoint /tiflash/tiflash us-docker.pkg.dev/pingcap-testing-account/dev/pingcap/tiflash/image:release-nextgen-20251011-experiment version

TiFlash
Release Version: v8.5.4-nextgen.202510.14
Edition:         Enterprise
Git Commit Hash: db4065600bc6467ce106d3e36a47906d2534ea69
Git Branch:      HEAD
UTC Build Time:  2026-06-10 04:43:57
Enable Features: jemalloc sm4(GmSSL) mem-profiling avx2 avx512 unwind thinlto next-gen hnsw.l2=skylake hnsw.cosine=skylake vec.l2=skylake vec.cos=skylake
Profile:         RELWITHDEBINFO
Compiler:        clang++ 17.0.6

Raft Proxy
Git Commit Hash:   88423ec06b17fc14d143f3f9b6cac506a29cce5f
Git Commit Branch: HEAD
UTC Build Time:    ""
Rust Version:      rustc 1.77.0-nightly (89e2160c4 2023-12-27)
Storage Engine:    tiflash
Prometheus Prefix: tiflash_proxy_
Profile:           release
Enable Features:   "raftstore-proxy/external-jemalloc" portable sse test-engine-kv-rocksdb test-engine-raft-raft-engine cloud-aws cloud-gcp cloud-azure portable sse test-engine-kv-rocksdb test-engine-raft-raft-engine cloud-aws cloud-gcp cloud-azure
# Start with -e TIFLASH_COLUMNAR=true. The same binary was started
>  podman run --rm -it -e TIFLASH_COLUMNAR=true --entrypoint /tiflash/tiflash us-docker.pkg.dev/pingcap-testing-account/dev/pingcap/tiflash/image:release-nextgen-20251011-experiment version

TiFlash
Release Version: v8.5.4-nextgen.202510.14
Edition:         Enterprise
Git Commit Hash: db4065600bc6467ce106d3e36a47906d2534ea69
Git Branch:      HEAD
UTC Build Time:  2026-06-10 04:43:57
Enable Features: jemalloc sm4(GmSSL) mem-profiling avx2 avx512 unwind thinlto next-gen hnsw.l2=skylake hnsw.cosine=skylake vec.l2=skylake vec.cos=skylake
Profile:         RELWITHDEBINFO
Compiler:        clang++ 17.0.6

Raft Proxy
Git Commit Hash:   88423ec06b17fc14d143f3f9b6cac506a29cce5f
Git Commit Branch: HEAD
UTC Build Time:    ""
Rust Version:      rustc 1.77.0-nightly (89e2160c4 2023-12-27)
Storage Engine:    tiflash
Prometheus Prefix: tiflash_proxy_
Profile:           release
Enable Features:   "raftstore-proxy/external-jemalloc" portable sse test-engine-kv-rocksdb test-engine-raft-raft-engine cloud-aws cloud-gcp cloud-azure portable sse test-engine-kv-rocksdb test-engine-raft-raft-engine cloud-aws cloud-gcp cloud-azure
```