### PR TITLE
fix(dockerfiles): retarget fips consumers to v1.11.3

### DIFF
--- a/dockerfiles/cd/builders/tikv/fips.Dockerfile
+++ b/dockerfiles/cd/builders/tikv/fips.Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,target=/tikv/target \
 RUN /ws/bin/tikv-server --version
 
 ########### stage: Final image
-FROM ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2-fips
+FROM ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3-fips
 
 ENV MALLOC_CONF="prof:true,prof_active:false"
 COPY --from=building /ws/bin/tikv-server  /tikv-server

--- a/dockerfiles/products/tikv/fips.Dockerfile
+++ b/dockerfiles/products/tikv/fips.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.2-fips
+ARG BASE_IMG=ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3-fips
 FROM $BASE_IMG
 COPY --chmod=755 tikv-server tikv-ctl /
 ENV MALLOC_CONF="prof:true,prof_active:false"


### PR DESCRIPTION
Summary
Retarget the remaining FIPS consumers to the FIPS base tag published by PR #997.

Refs FLA-182.

Changes
- Bump `dockerfiles/cd/builders/tikv/fips.Dockerfile` from `tikv-base:v1.11.2-fips` to `v1.11.3-fips`
- Bump `dockerfiles/products/tikv/fips.Dockerfile` from `tikv-base:v1.11.2-fips` to `v1.11.3-fips`

Testing
- `git diff --check`
- Manual EOF/trailing-whitespace check for changed files
- `docker manifest inspect ghcr.io/pingcap-qe/bases/tikv-base:v1.11.3-fips`

Risk
Low. This only retargets two existing FIPS Dockerfiles to the now-published FIPS base tag. Rollback is to restore `v1.11.2-fips` in the two files.
