### PR TITLE
feat(pingcap-base): preload rclone/shush to fix CI rate-limiting

### DIFF
--- a/dockerfiles/bases/pingcap-base/Dockerfile
+++ b/dockerfiles/bases/pingcap-base/Dockerfile
@@ -7,3 +7,24 @@ ARG PINGCAP_UID=1000
 ARG PINGCAP_GID=2000
 RUN groupadd -g ${PINGCAP_GID} pingcap && \
     useradd -u ${PINGCAP_UID} -g ${PINGCAP_GID} -m pingcap
+
+# Pre-install rclone and shush to avoid GitHub rate-limiting in CI.
+ARG TARGETARCH
+ARG RCLONE_VERSION=v1.71.2
+ARG SHUSH_VERSION=v1.5.5
+RUN dnf install -y unzip && dnf clean all && \
+    curl -fsSL -o /tmp/rclone.zip https://github.com/ncw/rclone/releases/download/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip && \
+    echo "$(case ${TARGETARCH} in \
+        amd64) echo ab9fa5877cee91c64fdfd61a27028a458cf618b39259e5c371dc2ec34a12e415;; \
+        arm64) echo e2e2efc7ed143026352d60216ef0d46d3fa4fe9d647eff1bd929e6fea498e6f1;; \
+    esac) /tmp/rclone.zip" | sha256sum -c - && \
+    unzip /tmp/rclone.zip -d /tmp && \
+    mv /tmp/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}/rclone /usr/local/bin/rclone && \
+    chmod 755 /usr/local/bin/rclone && \
+    rm -rf /tmp/rclone.zip /tmp/rclone-${RCLONE_VERSION}-linux-${TARGETARCH} && \
+    curl -fsSL -o /usr/local/bin/shush https://github.com/realestate-com-au/shush/releases/download/${SHUSH_VERSION}/shush_linux_${TARGETARCH} && \
+    echo "$(case ${TARGETARCH} in \
+        amd64) echo d0e091405a18b6d11a65ea1d7449802c0cbac51971031897089d038e6f7cc750;; \
+        arm64) echo 138af0f1eec3af50176d542fead8824c3ca0f6ba27a4a50e1db8af5959a13116;; \
+    esac) /usr/local/bin/shush" | sha256sum -c - && \
+    chmod 755 /usr/local/bin/shush

--- a/dockerfiles/bases/skaffold.yaml
+++ b/dockerfiles/bases/skaffold.yaml
@@ -60,7 +60,7 @@ build:
         dockerfile: debugging/Dockerfile
   tagPolicy:
     customTemplate:
-      template: "v1.11.3"
+      template: "v1.11.4"
   local:
     useDockerCLI: true
     useBuildkit: true
@@ -80,7 +80,7 @@ build:
         dockerfile: tikv-base/fips.Dockerfile
   tagPolicy:
     customTemplate:
-      template: "v1.11.3-fips"
+      template: "v1.11.4-fips"
   local:
     useDockerCLI: true
     useBuildkit: true


### PR DESCRIPTION
## Summary

Pre-install rclone v1.71.2 and shush v1.5.5 into the `pingcap-base` image with SHA256 checksum verification. This eliminates GitHub Release downloads during tidb-operator CI builds, fixing e2e CI failures caused by GitHub rate-limiting when concurrent jobs download these tools from the same GCP exit IP.

## Changes

- Add rclone v1.71.2 (amd64 + arm64) to `/usr/local/bin/rclone`
- Add shush v1.5.5 (amd64 + arm64) to `/usr/local/bin/shush`
- SHA256 checksum verification for all downloads (per Sentinel review recommendation)
- Bump base image tag from `v1.11.3` → `v1.11.4`

## Testing

- SHA256 checksums verified from official release sources:
  - rclone amd64: `ab9fa5877cee91c64fdfd61a27028a458cf618b39259e5c371dc2ec34a12e415`
  - rclone arm64: `e2e2efc7ed143026352d60216ef0d46d3fa4fe9d647eff1bd929e6fea498e6f1`
  - shush amd64: `d0e091405a18b6d11a65ea1d7449802c0cbac51971031897089d038e6f7cc750`
  - shush arm64: `138af0f1eec3af50176d542fead8824c3ca0f6ba27a4a50e1db8af5959a13116`
- Binaries verified as valid ELF executables for respective architectures

## Risk

- **Low risk**: Adding ~50MB to base image (rclone ~40MB + shush ~5MB), acceptable for CI image
- **Rollback**: Revert tidb-operator Dockerfiles to use old `wget` pattern with previous base image tag

## Related

- Design spec: [FLA-199](mention://issue/eeb64e5d-7340-4f06-a5cf-1670e042dbad)
- Blocked by: PR1 (this PR) must merge before PR2 (tidb-operator Dockerfile updates)