### PR TITLE
feat(packages): add delivery-config configMapGenerator for FluxCD

### DIFF
--- a/packages/kustomization.yaml
+++ b/packages/kustomization.yaml
@@ -8,3 +8,9 @@ configMapGenerator:
       - delivery.yaml
       - packages.yaml.tmpl
       - offline-packages.yaml.tmpl
+  - name: delivery-config
+    options:
+      disableNameSuffixHash: true
+    files:
+      - delivery.yaml
+      - scripts/gen-delivery-image-commands.ts


### PR DESCRIPTION
## Summary

Add `delivery-config` configMapGenerator entry to `packages/kustomization.yaml` to enable FluxCD to generate ConfigMaps for delivery configs.

## Changes

- Added `delivery-config` configMapGenerator entry containing:
  - `delivery.yaml`
  - `scripts/gen-delivery-image-commands.ts`

## Testing

- Verified kustomize build generates the expected ConfigMap
- No existing ConfigMaps are affected (additive change only)

## Risk

Low - additive change only. Existing `packages-config` ConfigMap is unchanged.

## Related

- FLA-210 PR1: FluxCD ConfigMap generation for delivery configs
- FLA-180: CD config map requirement