### PR TITLE
feat(bases): bump pingcap-base to v1.12.0 with rockylinux 9.8 and openssl

### DIFF
--- a/.github/workflows/pull-prod-runtime-images.yaml
+++ b/.github/workflows/pull-prod-runtime-images.yaml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        module: [default, fips, release-6-5]
+        module: [default, release-6-5]
         platform: [linux/amd64, linux/arm64]
 
     steps:

--- a/.github/workflows/pull-prod-runtime-images.yaml
+++ b/.github/workflows/pull-prod-runtime-images.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup skaffold
         uses: heypigeonhq/setup-skaffold@3b1a0687de1b580d3879bf6b9d423255c9954587
         with:
-          version: 2.16.0
+          version: 2.23.0
 
       - name: Setup manifest-tool
         run: |

--- a/.github/workflows/release-prod-runtime-images.yaml
+++ b/.github/workflows/release-prod-runtime-images.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup skaffold
         uses: heypigeonhq/setup-skaffold@3b1a0687de1b580d3879bf6b9d423255c9954587
         with:
-          version: 2.16.0
+          version: 2.23.0
 
       - name: Setup manifest-tool
         run: |

--- a/.github/workflows/release-prod-runtime-images.yaml
+++ b/.github/workflows/release-prod-runtime-images.yaml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        module: [default, fips, release-6-5]
+        module: [default, release-6-5]
 
     steps:
       - name: Checkout sources

--- a/dockerfiles/bases/pingcap-base/Dockerfile
+++ b/dockerfiles/bases/pingcap-base/Dockerfile
@@ -1,9 +1,9 @@
-FROM quay.io/rockylinux/rockylinux:9.7.20251123
-COPY --from=busybox:1.37.0-musl /bin/busybox /bin/busybox
-RUN _date=20260609 dnf upgrade -y && dnf clean all
+FROM quay.io/rockylinux/rockylinux:9.8.20260525.0
+COPY --from=busybox:1.38.0-musl /bin/busybox /bin/busybox
 
-# Add user and group to support run it with non-root.
+ARG _date=20260714
 ARG PINGCAP_UID=1000
 ARG PINGCAP_GID=2000
-RUN groupadd -g ${PINGCAP_GID} pingcap && \
+RUN dnf upgrade -y && dnf clean all && \
+    groupadd -g ${PINGCAP_GID} pingcap && \
     useradd -u ${PINGCAP_UID} -g ${PINGCAP_GID} -m pingcap

--- a/dockerfiles/bases/skaffold.yaml
+++ b/dockerfiles/bases/skaffold.yaml
@@ -60,32 +60,13 @@ build:
         dockerfile: debugging/Dockerfile
   tagPolicy:
     customTemplate:
-      template: "v1.11.3"
+      template: "v1.12.0"
   local:
     useDockerCLI: true
     useBuildkit: true
     concurrency: 0
     tryImportMissing: true
 
----
-apiVersion: skaffold/v4beta6
-kind: Config
-metadata:
-  name: fips
-build:
-  artifacts:
-    - image: tikv-base
-      platforms: [linux/amd64, linux/arm64]
-      docker:
-        dockerfile: tikv-base/fips.Dockerfile
-  tagPolicy:
-    customTemplate:
-      template: "v1.11.3-fips"
-  local:
-    useDockerCLI: true
-    useBuildkit: true
-    concurrency: 0
-    tryImportMissing: true
 ---
 apiVersion: skaffold/v4beta6
 kind: Config

--- a/dockerfiles/bases/tikv-base/Dockerfile
+++ b/dockerfiles/bases/tikv-base/Dockerfile
@@ -1,6 +1,6 @@
 ARG PINGCAP_BASE
 FROM $PINGCAP_BASE
 # wget is requested by operator
-RUN dnf install -y tzdata wget && dnf clean all
+RUN dnf install -y tzdata wget openssl && dnf clean all
 ENV TZ=/etc/localtime \
     TZDIR=/usr/share/zoneinfo

--- a/dockerfiles/bases/tikv-base/fips.Dockerfile
+++ b/dockerfiles/bases/tikv-base/fips.Dockerfile
@@ -1,6 +1,0 @@
-ARG PINGCAP_BASE=ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.3
-FROM $PINGCAP_BASE
-# wget is requested by operator
-RUN dnf install -y tzdata wget openssl && dnf clean all
-ENV TZ=/etc/localtime \
-    TZDIR=/usr/share/zoneinfo


### PR DESCRIPTION
Updates:

- **pingcap-base**: bump rockylinux 9.7→9.8, busybox 1.37.0→1.38.0, move `_date` from shell var to proper ARG, squash RUN layers
- **tikv-base**: add openssl package, remove redundant fips.Dockerfile (now identical to main)
- **skaffold.yaml**: bump tag v1.11.3→v1.12.0, remove fips config section