### PR TITLE
feat: replace raw GitHub URLs with jsDelivr CDN for nvm install and Go zoneinfo

### DIFF
--- a/dockerfiles/bases/ng-monitoring-base/release-6.5.Dockerfile
+++ b/dockerfiles/bases/ng-monitoring-base/release-6.5.Dockerfile
@@ -11,4 +11,4 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-ADD https://github.com/golang/go/raw/go1.23.1/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
+ADD https://cdn.jsdelivr.net/gh/golang/go@go1.23.1/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip

--- a/dockerfiles/bases/tools-base/release-6.5.Dockerfile
+++ b/dockerfiles/bases/tools-base/release-6.5.Dockerfile
@@ -1,6 +1,6 @@
 ############## linux/amd64 ##################
 FROM pingcap/alpine-glibc:alpine-3.14.6 AS amd64
-ADD https://github.com/golang/go/raw/go1.22.5/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
+ADD https://cdn.jsdelivr.net/gh/golang/go@go1.22.5/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
 
 ############## linux/arm64 ##################
 FROM pingcap/centos-stream:8 AS arm64
@@ -12,4 +12,4 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
     && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
     && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-ADD https://github.com/golang/go/raw/go1.23.1/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
+ADD https://cdn.jsdelivr.net/gh/golang/go@go1.23.1/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip

--- a/dockerfiles/cd/builders/tiflow/Dockerfile
+++ b/dockerfiles/cd/builders/tiflow/Dockerfile
@@ -31,7 +31,7 @@ ARG NODE_VERSION=18.20.8
 ARG NVM_VERSION=v0.40.5
 ARG NVM_DIR=/usr/local/nvm
 RUN mkdir -p $NVM_DIR && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash && \
+    curl -o- https://cdn.jsdelivr.net/gh/nvm-sh/nvm@${NVM_VERSION}/install.sh | bash && \
     . $NVM_DIR/nvm.sh && \
     nvm install ${NODE_VERSION} && \
     nvm use v${NODE_VERSION} && \

--- a/dockerfiles/cd/builders/tiflow/centos7/Dockerfile
+++ b/dockerfiles/cd/builders/tiflow/centos7/Dockerfile
@@ -40,7 +40,7 @@ ARG NODE_VERSION=16.20.2
 ARG NVM_VERSION=v0.40.5
 ARG NVM_DIR=/usr/local/nvm
 RUN mkdir -p $NVM_DIR && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash && \
+    curl -o- https://cdn.jsdelivr.net/gh/nvm-sh/nvm@${NVM_VERSION}/install.sh | bash && \
     . $NVM_DIR/nvm.sh && \
     nvm install ${NODE_VERSION} && \
     nvm use v${NODE_VERSION} && \

--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -2279,7 +2279,7 @@ components:
                 mkdir -p $NVM_DIR
 
                 if [ ! -s "$NVM_DIR/nvm.sh" ]; then
-                  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
+                  curl -o- https://cdn.jsdelivr.net/gh/nvm-sh/nvm@${NVM_VERSION}/install.sh | bash
                 fi
                 . $NVM_DIR/nvm.sh
                 nvm install ${NODE_VERSION}
@@ -2300,7 +2300,7 @@ components:
                 mkdir -p $NVM_DIR
 
                 if [ ! -s "$NVM_DIR/nvm.sh" ]; then
-                  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
+                  curl -o- https://cdn.jsdelivr.net/gh/nvm-sh/nvm@${NVM_VERSION}/install.sh | bash
                 fi
                 . $NVM_DIR/nvm.sh
                 nvm install ${NODE_VERSION}
@@ -2430,7 +2430,7 @@ components:
                 mkdir -p $NVM_DIR
 
                 if [ ! -s "$NVM_DIR/nvm.sh" ]; then
-                  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
+                  curl -o- https://cdn.jsdelivr.net/gh/nvm-sh/nvm@${NVM_VERSION}/install.sh | bash
                 fi
                 . $NVM_DIR/nvm.sh
                 nvm install ${NODE_VERSION}
@@ -2556,7 +2556,7 @@ components:
                 mkdir -p $NVM_DIR
 
                 if [ ! -s "$NVM_DIR/nvm.sh" ]; then
-                  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
+                  curl -o- https://cdn.jsdelivr.net/gh/nvm-sh/nvm@${NVM_VERSION}/install.sh | bash
                 fi
                 . $NVM_DIR/nvm.sh
                 nvm install ${NODE_VERSION}
@@ -2662,7 +2662,7 @@ components:
                 mkdir -p $NVM_DIR
 
                 if [ ! -s "$NVM_DIR/nvm.sh" ]; then
-                  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
+                  curl -o- https://cdn.jsdelivr.net/gh/nvm-sh/nvm@${NVM_VERSION}/install.sh | bash
                 fi
                 . $NVM_DIR/nvm.sh
                 nvm install ${NODE_VERSION}
@@ -2816,7 +2816,7 @@ components:
                 mkdir -p $NVM_DIR
 
                 if [ ! -s "$NVM_DIR/nvm.sh" ]; then
-                  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
+                  curl -o- https://cdn.jsdelivr.net/gh/nvm-sh/nvm@${NVM_VERSION}/install.sh | bash
                 fi
                 . $NVM_DIR/nvm.sh
                 nvm install ${NODE_VERSION}


### PR DESCRIPTION
Summary:
Replace raw.githubusercontent.com (nvm install scripts, 8 occurrences) and github.com/.../raw/ (Go zoneinfo, 3 occurrences) URLs with jsDelivr CDN equivalents in the artifacts repo.

Changes:
- `packages/packages.yaml.tmpl`: 6 nvm install URLs → `cdn.jsdelivr.net/gh/nvm-sh/nvm@${NVM_VERSION}/install.sh`
- `dockerfiles/cd/builders/tiflow/Dockerfile`: 1 nvm install URL → same pattern
- `dockerfiles/cd/builders/tiflow/centos7/Dockerfile`: 1 nvm install URL → same pattern
- `dockerfiles/bases/tools-base/release-6.5.Dockerfile`: 2 Go zoneinfo URLs → `cdn.jsdelivr.net/gh/golang/go@goX.Y.Z/lib/time/zoneinfo.zip`
- `dockerfiles/bases/ng-monitoring-base/release-6.5.Dockerfile`: 1 Go zoneinfo URL → same pattern

Testing: URL transport only, no logic changes. Docker image builds should succeed with identical zoneinfo/nvm artifacts.

Risk: Low. jsDelivr CDN is multi-CDN backed with better SLA than raw.githubusercontent.com.