### PR TITLE
chore(deps): use Go 1.25.12 builders

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -288,7 +288,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 8.5.6-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2026.4.12-31-g809b8b4-centos7-go1.25
+        image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2026.7.19-6-gfc3279c-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.5.5-0, < 8.5.6-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2025.12.7-9-ga45d5b1-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.4.0-0, < 8.5.5-0" .Release.version }}
@@ -446,7 +446,7 @@ components:
         - {{ .Release.version }}
     builders:
       - if: {{ semver.CheckConstraint ">= 8.5.6-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2026.4.12-31-g809b8b4-centos7-go1.25
+        image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2026.7.19-6-gfc3279c-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.5.5-0, < 8.5.6-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/ng-monitoring:v2025.12.7-9-ga45d5b1-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.4.0-0, < 8.5.5-0" .Release.version }}
@@ -573,7 +573,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 8.5.6-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/pd:v2026.4.12-31-g809b8b4-centos7-go1.25
+        image: ghcr.io/pingcap-qe/cd/builders/pd:v2026.7.19-6-gfc3279c-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.5.5-0, < 8.5.6-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/pd:v2025.12.7-3-g1c0b8cf-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.4.0-0, < 8.5.5-0" .Release.version }}
@@ -922,7 +922,9 @@ components:
         - {{ .Release.version }}
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
-      - if: {{ semver.CheckConstraint ">= 8.5.6-0" .Release.version }}
+      - if: {{ semver.CheckConstraint ">= 8.5.8-0" .Release.version }}
+        image: ghcr.io/pingcap-qe/cd/builders/tidb:v2026.7.19-6-gfc3279c-centos7-go1.25
+      - if: {{ semver.CheckConstraint ">= 8.5.6-0, < 8.5.8-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/tidb:v2026.4.12-31-g809b8b4-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.5.5-0, < 8.5.6-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/tidb:v2025.12.7-14-g6fd6d9d-centos7-go1.25
@@ -1751,7 +1753,7 @@ components:
         - {{ .Release.version }}
     builders:
       - if: {{ semver.CheckConstraint ">= 8.5.6-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/tidb-dashboard:v2026.4.12-31-g809b8b4-centos7-go1.25
+        image: ghcr.io/pingcap-qe/cd/builders/tidb-dashboard:v2026.7.19-6-gfc3279c-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.5.5-0, < 8.5.6-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/tidb-dashboard:v2025.12.7-3-g1c0b8cf-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.4.0-0, < 8.5.5-0" .Release.version }}
@@ -2248,7 +2250,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 8.5.6-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/tiflow:v2026.4.12-31-g809b8b4-centos7-go1.25
+        image: ghcr.io/pingcap-qe/cd/builders/tiflow:v2026.7.19-6-gfc3279c-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.5.5-0, < 8.5.6-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/tiflow:v2025.12.14-3-g63aefbf-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.4.0-0, < 8.5.5-0" .Release.version }}
@@ -2944,7 +2946,7 @@ components:
     # binary builder, also we need it when build for mac to get build tools versions and other informations.
     builders:
       - if: {{ semver.CheckConstraint ">= 8.5.6-0" .Release.version }}
-        image: ghcr.io/pingcap-qe/cd/builders/ticdc:v2026.4.12-31-g809b8b4-centos7-go1.25
+        image: ghcr.io/pingcap-qe/cd/builders/ticdc:v2026.7.19-6-gfc3279c-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.5.5-0, < 8.5.6-0" .Release.version }}
         image: ghcr.io/pingcap-qe/cd/builders/ticdc:v2025.12.14-3-g63aefbf-centos7-go1.25
       - if: {{ semver.CheckConstraint ">= 8.5.4-0, < 8.5.5-0" .Release.version }}


### PR DESCRIPTION
Use the builder images produced from artifacts#987 with Go 1.25.12 for the requested components.

Changes:
- update ng-monitoring, PD, TiFlow, TiCDC, and TiDB Dashboard builders for v8.5.6+
- update TiDB to use the new builder only for v8.5.8+; retain the existing v8.5.6–v8.5.7 routing
- enterprise-plugin and tikv/client-go are built as part of the TiDB/PD workflows and have no standalone builder entries in this repository

Validation:
- verified all six new GHCR builder image tags exist
- git diff --check