### PR TITLE
fix(ci): make weekly image-scan email step configurable and non-blocking

### DIFF
--- a/.github/workflows/weekly-release.yaml
+++ b/.github/workflows/weekly-release.yaml
@@ -101,6 +101,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      SMTP_SERVER: ${{ secrets.SMTP_SERVER }}
+      SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+      SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -138,9 +142,13 @@ jobs:
           echo "has_vulns=${has_vulns}" >> "$GITHUB_OUTPUT"
 
       - name: Send scan report via email
-        if: always()
+        if: always() && env.SMTP_SERVER != ''
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
         with:
+          server_address: ${{ env.SMTP_SERVER }}
+          server_port: ${{ secrets.SMTP_PORT || 465 }}
+          username: ${{ env.SMTP_USERNAME }}
+          password: ${{ env.SMTP_PASSWORD }}
           to: ci@pingcap.com
           from: GitHub Actions <actions@github.com>
           subject: Weekly Trivy scan report - bases (default)
@@ -149,3 +157,8 @@ jobs:
 
             Results are shown in the workflow log above.
             See: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Notify email report skipped
+        if: always() && env.SMTP_SERVER == ''
+        run: |
+          echo "::warning::SMTP_SERVER secret is not configured; scan report email skipped. Set SMTP_SERVER / SMTP_USERNAME / SMTP_PASSWORD repo secrets to enable email delivery."


### PR DESCRIPTION
## Summary

Fixes the failing `image-scan` job in the Weekly GitHub Release workflow (run 30724933098). The job failed at the "Send scan report via email" step with `Server address must be specified` because the `dawidd6/action-send-mail` step never received SMTP configuration.

## Changes

- Read SMTP server/credentials from repo secrets (`SMTP_SERVER`, `SMTP_USERNAME`, `SMTP_PASSWORD`, optional `SMTP_PORT`)
- Gate the email step on `env.SMTP_SERVER != ''`: when SMTP is not configured the email step is skipped instead of failing the whole weekly run
- Add a fallback step that emits a warning when the report email is skipped, so the condition is visible in logs

## Testing

- YAML validated with js-yaml
- Workflow only runs on schedule/manual trigger; the email step now degrades gracefully when secrets are absent, so the next scheduled run will pass regardless of secret availability. Full email delivery verification pending SMTP credentials.

## Risk

Low. When SMTP secrets are configured, behavior matches the original intent (email report); otherwise the step is skipped with a warning instead of failing the job.