### PR TITLE
test(packages): add plugin loading test with tidb-server for enterprise profile

### DIFF
--- a/packages/packages.yaml.tmpl
+++ b/packages/packages.yaml.tmpl
@@ -972,6 +972,12 @@ components:
                 # go plugin whitelist
                 pushd ../enterprise-plugin/whitelist && go mod tidy &&  popd
                 go run ./cmd/pluginpkg -pkg-dir ../enterprise-plugin/whitelist -out-dir bin/
+            - script: |
+                # test loading the plugins with tidb-server.
+                bin/tidb-server -plugin-dir=./bin -plugin-load=audit-1,whitelist-1 | tee ./loading-plugin.log &
+                sleep 30
+                pgrep -x tidb-server
+                pkill -9 -x tidb-server
           enterprise-without-plugins:
             - script: |
                 TIDB_EDITION=Enterprise make enterprise-prepare enterprise-server-build build_tools build_dumpling
@@ -1121,6 +1127,12 @@ components:
                 # go plugin whitelist
                 pushd ../enterprise-plugin/whitelist && go mod tidy &&  popd
                 go run ./cmd/pluginpkg -pkg-dir ../enterprise-plugin/whitelist -out-dir bin/
+            - script: |
+                # test loading the plugins with tidb-server.
+                bin/tidb-server -plugin-dir=./bin -plugin-load=audit-1,whitelist-1 | tee ./loading-plugin.log &
+                sleep 30
+                pgrep -x tidb-server
+                pkill -9 -x tidb-server
           enterprise-without-plugins:
             - script: |
                 TIDB_EDITION=Enterprise make enterprise-prepare enterprise-server-build build_tools build_dumpling
@@ -1265,6 +1277,12 @@ components:
                 # go plugin whitelist
                 pushd ../enterprise-plugin/whitelist && go mod tidy &&  popd
                 go run ./cmd/pluginpkg -pkg-dir ../enterprise-plugin/whitelist -out-dir bin/
+            - script: |
+                # test loading the plugins with tidb-server.
+                bin/tidb-server -plugin-dir=./bin -plugin-load=audit-1,whitelist-1 | tee ./loading-plugin.log &
+                sleep 30
+                pgrep -x tidb-server
+                pkill -9 -x tidb-server
           failpoint:
             - script: |
                 make failpoint-enable


### PR DESCRIPTION
## What

For the `enterprise` profile of the `tidb` component, after building the audit/whitelist plugins, verify they can actually be loaded by the packaged `tidb-server`:

- start `tidb-server` with `-plugin-dir=./bin -plugin-load=audit-1,whitelist-1`
- wait 30s, then assert the process is still running via `pgrep -x tidb-server`
- clean up with `pkill -9 -x tidb-server`

## Notes

- The builder image (centos7) does **not** ship `killall`, so `pkill`/`pgrep` are used instead (both verified present in `ghcr.io/pingcap-qe/cd/builders/tidb:*`).
- If plugin loading fails, `bootstrapSessionImpl` returns an error and tidb-server exits, so the `pgrep` assertion catches broken plugins.
- Applied to all three version-range routers that build plugins (\>=8.4.0, 7.1.0~8.4.0, 6.1.0~7.1.0).